### PR TITLE
Fix consurg map crashes and add new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ explorer: false
 | `consurg on` / `off` | Activate or deactivate scope |
 | `consurg status` | Show tier counts and patterns |
 | `consurg audit-status` | Show effective audit config and local audit storage usage |
-| `consurg map` | Visualize files as a tree with tier badges |
+| `consurg clean [--keep-scope]` | Deactivate scope, unwire all tools, and remove scope file |
+| `consurg map [--scoped-only] [--depth N]` | Visualize files as a tree with tier badges |
 | `consurg trace ENTRIES [--depth N] [--apply]` | Build scope from dependency graph |
 | `consurg git-diff [BASE] [--apply]` | Build scope from branch diff |
 | `consurg export --format FMT` | Export as claude, cursor, aider, or generic |

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ explorer: false
 | `consurg remove FILES` | Remove patterns from all tiers |
 | `consurg on` / `off` | Activate or deactivate scope |
 | `consurg status` | Show tier counts and patterns |
+| `consurg audit-status` | Show effective audit config and local audit storage usage |
 | `consurg map` | Visualize files as a tree with tier badges |
 | `consurg trace ENTRIES [--depth N] [--apply]` | Build scope from dependency graph |
 | `consurg git-diff [BASE] [--apply]` | Build scope from branch diff |
@@ -135,6 +136,8 @@ explorer: false
 | `consurg guard [-i] [--port N] [--no-tui]` | Start interactive scope firewall |
 | `consurg wire TOOL [--unwire]` | Auto-configure hooks for a tool |
 | `consurg wrap -- CMD [ARGS]` | Run command with embedded scope enforcement |
+| `consurg scaffold-pk-agents [--force]` | Create pk-agent scope selector + excluded-context summarizer |
+| `consurg apply-proposal [--proposal-file PATH] [--apply]` | Map scope-proposal output into `.consurg.yaml` |
 | `consurg pin` / `unpin` | Save or remove scope file |
 
 ## Supported Tools
@@ -149,6 +152,31 @@ explorer: false
 
 Unwire with `consurg wire <tool> --unwire`.
 
+## pk-agent Scope Automation
+
+Create the two-agent system for scope planning and excluded-context review:
+
+```bash
+consurg scaffold-pk-agents
+```
+
+This generates:
+- `.agents/pk-agents/consurg-scope-selector.pk-agent`
+- `.agents/pk-agents/consurg-excluded-summarizer.pk-agent`
+- `.agents/pk-agents/README.md` (runbook)
+
+Apply proposal output into Consurg tiers:
+
+```bash
+consurg apply-proposal --apply
+```
+
+Install dependency if needed:
+
+```bash
+npm i -g pk-agent
+```
+
 ## Documentation
 
 Detailed documentation is in the [`docs/`](docs/) directory:
@@ -162,6 +190,7 @@ Detailed documentation is in the [`docs/`](docs/) directory:
 - **[Export Adapters](docs/adapters.md)** -- Generating tool-specific scope formats
 - **[CLI Reference](docs/cli-reference.md)** -- Full reference for every command and option
 - **[Architecture](docs/architecture.md)** -- System design, threading model, data flow
+- **[pk-agent Audit Integration](docs/pk-agent-audit-integration.md)** -- Opt-in hardened audit telemetry contract (redaction + retention)
 
 ## Development
 

--- a/consurg/audit.py
+++ b/consurg/audit.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+SCHEMA_VERSION = "1.0"
+REDACTION_ERROR_SENTINEL = "[REDACTION_ERROR]"
+TRUNCATION_MARKER = "...[TRUNCATED]"
+DEFAULT_MAX_STRING = 4096
+
+_SENSITIVE_KEYS = {
+    "password",
+    "passwd",
+    "token",
+    "secret",
+    "authorization",
+    "api_key",
+    "private_key",
+    "client_secret",
+}
+
+_SECRET_PATTERNS = [
+    re.compile(r"(?i)\b(authorization)\s*:\s*([^\s,;]+)"),
+    re.compile(r"(?i)\b(bearer)\s+[a-z0-9\-._~+/]+=*", re.IGNORECASE),
+    re.compile(r"(?i)\b(basic)\s+[a-z0-9\-._~+/]+=*", re.IGNORECASE),
+    re.compile(r"\beyJ[a-zA-Z0-9_\-]{8,}\.[a-zA-Z0-9_\-]{8,}\.[a-zA-Z0-9_\-]{8,}\b"),
+    re.compile(r"\bsk-[a-zA-Z0-9]{12,}\b"),
+]
+
+
+@dataclass
+class AuditConfig:
+    enabled: bool = False
+    storage_path: Path = Path(".pk-agent") / "runs"
+    max_runs: int = 200
+    max_age_days: int = 14
+    max_bytes: int = 104857600
+    redaction_profile: str = "strict-v1"
+    include_tool_names: list[str] = None  # type: ignore[assignment]
+    exclude_tool_names: list[str] = None  # type: ignore[assignment]
+
+    def __post_init__(self):
+        if self.include_tool_names is None:
+            self.include_tool_names = ["*"]
+        if self.exclude_tool_names is None:
+            self.exclude_tool_names = []
+
+
+def load_audit_config(project_root: Path, env: dict[str, str] | None = None) -> AuditConfig:
+    env = env or os.environ
+    config = AuditConfig()
+    config_path = project_root / ".consurg-audit.yaml"
+    file_config: dict[str, Any] = {}
+
+    if config_path.exists():
+        loaded = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+        if isinstance(loaded, dict):
+            file_config = loaded
+
+    if "enabled" in file_config:
+        config.enabled = bool(file_config["enabled"])
+    if "storage_path" in file_config and isinstance(file_config["storage_path"], str):
+        config.storage_path = Path(file_config["storage_path"])
+    if "max_runs" in file_config:
+        config.max_runs = _to_int(file_config["max_runs"], default=config.max_runs)
+    if "max_age_days" in file_config:
+        config.max_age_days = _to_int(file_config["max_age_days"], default=config.max_age_days)
+    if "max_bytes" in file_config:
+        config.max_bytes = _to_int(file_config["max_bytes"], default=config.max_bytes)
+    if "redaction_profile" in file_config and isinstance(file_config["redaction_profile"], str):
+        config.redaction_profile = file_config["redaction_profile"]
+    if "include_tool_names" in file_config and isinstance(file_config["include_tool_names"], list):
+        config.include_tool_names = [str(v) for v in file_config["include_tool_names"]]
+    if "exclude_tool_names" in file_config and isinstance(file_config["exclude_tool_names"], list):
+        config.exclude_tool_names = [str(v) for v in file_config["exclude_tool_names"]]
+
+    if env.get("CONSURG_AUDIT_PERSIST") == "1":
+        config.enabled = True
+    if env.get("CONSURG_AUDIT_MAX_RUNS"):
+        config.max_runs = _to_int(env["CONSURG_AUDIT_MAX_RUNS"], default=config.max_runs)
+    if env.get("CONSURG_AUDIT_MAX_AGE_DAYS"):
+        config.max_age_days = _to_int(env["CONSURG_AUDIT_MAX_AGE_DAYS"], default=config.max_age_days)
+    if env.get("CONSURG_AUDIT_MAX_BYTES"):
+        config.max_bytes = _to_int(env["CONSURG_AUDIT_MAX_BYTES"], default=config.max_bytes)
+
+    if not config.storage_path.is_absolute():
+        config.storage_path = project_root / config.storage_path
+
+    return config
+
+
+def should_audit_tool(tool_name: str, config: AuditConfig) -> bool:
+    if not config.enabled:
+        return False
+    if "*" not in config.include_tool_names and tool_name not in config.include_tool_names:
+        return False
+    if tool_name in config.exclude_tool_names:
+        return False
+    return True
+
+
+def persist_trace(
+    config: AuditConfig,
+    run_id: str,
+    started_at: datetime,
+    tool_calls: list[dict[str, Any]],
+) -> Path:
+    timestamp_dir = started_at.astimezone(UTC).strftime("%Y%m%dT%H%M%SZ")
+    run_dir = config.storage_path / timestamp_dir
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    redacted_calls = [_redact_tool_call(call) for call in tool_calls]
+
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": run_id,
+        "started_at": started_at.astimezone(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "tool_calls": redacted_calls,
+        "retention_policy_snapshot": {
+            "max_runs": config.max_runs,
+            "max_age_days": config.max_age_days,
+            "max_bytes": config.max_bytes,
+        },
+    }
+
+    trace_path = run_dir / "trace.json"
+    trace_path.write_text(json.dumps(payload, indent=2, ensure_ascii=True), encoding="ascii")
+    prune_runs(config)
+    return trace_path
+
+
+def prune_runs(config: AuditConfig, now: datetime | None = None):
+    now = now or datetime.now(UTC)
+    config.storage_path.mkdir(parents=True, exist_ok=True)
+
+    runs = []
+    for child in config.storage_path.iterdir():
+        if not child.is_dir():
+            continue
+        ts = _parse_run_ts(child.name)
+        if ts is None:
+            continue
+        runs.append((child, ts))
+
+    runs.sort(key=lambda x: x[1])
+
+    age_cutoff = now - timedelta(days=config.max_age_days)
+    remaining: list[tuple[Path, datetime]] = []
+    for run_dir, ts in runs:
+        if ts < age_cutoff:
+            _safe_rmtree(run_dir)
+        else:
+            remaining.append((run_dir, ts))
+
+    while len(remaining) > config.max_runs:
+        oldest, _ = remaining.pop(0)
+        _safe_rmtree(oldest)
+
+    def _total_bytes(paths: list[tuple[Path, datetime]]) -> int:
+        total = 0
+        for run_dir, _ in paths:
+            total += _dir_bytes(run_dir)
+        return total
+
+    while remaining and _total_bytes(remaining) > config.max_bytes:
+        oldest, _ = remaining.pop(0)
+        _safe_rmtree(oldest)
+
+
+def audit_storage_stats(storage_path: Path) -> dict[str, int]:
+    if not storage_path.exists():
+        return {"runs": 0, "bytes": 0}
+
+    runs = 0
+    total_bytes = 0
+    for child in storage_path.iterdir():
+        if child.is_dir() and _parse_run_ts(child.name) is not None:
+            runs += 1
+            total_bytes += _dir_bytes(child)
+    return {"runs": runs, "bytes": total_bytes}
+
+
+def _to_int(value: Any, default: int) -> int:
+    try:
+        parsed = int(value)
+        return parsed if parsed > 0 else default
+    except (TypeError, ValueError):
+        return default
+
+
+def _parse_run_ts(name: str) -> datetime | None:
+    try:
+        return datetime.strptime(name, "%Y%m%dT%H%M%SZ").replace(tzinfo=UTC)
+    except ValueError:
+        return None
+
+
+def _dir_bytes(path: Path) -> int:
+    total = 0
+    for p in path.rglob("*"):
+        if p.is_file():
+            try:
+                total += p.stat().st_size
+            except OSError:
+                continue
+    return total
+
+
+def _safe_rmtree(path: Path):
+    for p in sorted(path.rglob("*"), reverse=True):
+        try:
+            if p.is_file():
+                p.unlink()
+            elif p.is_dir():
+                p.rmdir()
+        except OSError:
+            continue
+    try:
+        path.rmdir()
+    except OSError:
+        pass
+
+
+def _redact_tool_call(call: dict[str, Any]) -> dict[str, Any]:
+    flags: set[str] = set()
+    name = _ascii_truncate(str(call.get("name", "unknown")))
+    call_type = _ascii_truncate(str(call.get("type", "tool")))
+    success = bool(call.get("success", False))
+    start_time = _to_int(call.get("start_time"), 0)
+    duration_ms = _to_int(call.get("duration_ms"), 0)
+
+    try:
+        raw_input = call.get("input")
+        redacted_input = _redact_value(raw_input, flags=flags, key_hint=None)
+    except Exception:
+        redacted_input = REDACTION_ERROR_SENTINEL
+        flags.add("redaction_error")
+
+    try:
+        raw_output = call.get("output")
+        redacted_output = _redact_value(raw_output, flags=flags, key_hint=None)
+    except Exception:
+        redacted_output = REDACTION_ERROR_SENTINEL
+        flags.add("redaction_error")
+
+    return {
+        "name": name,
+        "type": call_type,
+        "start_time": start_time,
+        "duration_ms": duration_ms,
+        "success": success,
+        "redacted_input": _ascii_truncate(_stringify(redacted_input)),
+        "redacted_output": _ascii_truncate(_stringify(redacted_output)),
+        "redaction_flags": sorted(flags),
+    }
+
+
+def _redact_value(value: Any, flags: set[str], key_hint: str | None) -> Any:
+    if isinstance(value, dict):
+        out: dict[str, Any] = {}
+        for k, v in value.items():
+            key = str(k)
+            if key.lower() in _SENSITIVE_KEYS:
+                out[key] = "[REDACTED]"
+                flags.add(f"field:{key.lower()}")
+                continue
+            out[key] = _redact_value(v, flags=flags, key_hint=key.lower())
+        return out
+
+    if isinstance(value, list):
+        return [_redact_value(v, flags=flags, key_hint=key_hint) for v in value]
+
+    as_text = _stringify(value)
+    if key_hint and key_hint in _SENSITIVE_KEYS:
+        flags.add(f"field:{key_hint}")
+        return "[REDACTED]"
+
+    redacted = as_text
+    for idx, pattern in enumerate(_SECRET_PATTERNS):
+        if pattern.search(redacted):
+            redacted = pattern.sub("[REDACTED]", redacted)
+            flags.add(f"pattern:{idx}")
+
+    return redacted
+
+
+def _stringify(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, ensure_ascii=True, sort_keys=True)
+    except Exception:
+        return str(value)
+
+
+def _ascii_truncate(value: str, max_len: int = DEFAULT_MAX_STRING) -> str:
+    clean = value.encode("ascii", "replace").decode("ascii")
+    if len(clean) <= max_len:
+        return clean
+    return clean[: max_len - len(TRUNCATION_MARKER)] + TRUNCATION_MARKER

--- a/consurg/cli.py
+++ b/consurg/cli.py
@@ -1,7 +1,10 @@
 import os
 import subprocess
 import sys
+import time
+import uuid
 from collections import deque
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Annotated
 
@@ -17,6 +20,8 @@ from consurg.adapters import (
     generate_cursor_rules,
     generate_generic_prompt,
 )
+from consurg.audit import audit_storage_stats, load_audit_config, persist_trace, should_audit_tool
+from consurg.pk_agents import scaffold_pk_agents
 from consurg.scope import Scope, load_scope
 from consurg.trace import DependencyGraph, resolve_python_imports, resolve_ts_imports
 
@@ -185,7 +190,10 @@ def status():
 
 
 @app.command(name="map")
-def map_cmd():
+def map_cmd(
+    depth: Annotated[int | None, typer.Option("--depth", "-d", help="Maximum depth to traverse.")] = None,
+    scoped_only: Annotated[bool, typer.Option("--scoped-only", help="Only show files with tier >= 1.")] = False,
+):
     """Visualize file tiers as a tree."""
     from rich.text import Text
     from rich.tree import Tree
@@ -208,12 +216,34 @@ def map_cmd():
         0: ("[--]", "dim", "dash"),
     }
 
-    files = sorted(p.relative_to(cwd) for p in cwd.rglob("*") if p.is_file()
-                   and ".git" not in p.parts and "__pycache__" not in p.parts
-                   and ".pytest_cache" not in p.parts)
+    # 1. Use git ls-files for file discovery
+    try:
+        # Include both cached (tracked) and other (untracked) files, respecting .gitignore
+        result = subprocess.run(['git', 'ls-files', '--cached', '--others', '--exclude-standard'], capture_output=True, text=True, check=True, cwd=cwd)
+        files = [Path(f) for f in result.stdout.splitlines()]
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        # Fallback to rglob with extended ignore list
+        ignore_list = {".git", "__pycache__", ".pytest_cache", "node_modules", "dist", "build", ".venv", "venv", "env"}
+        files = [p.relative_to(cwd) for p in cwd.rglob("*")
+                 if p.is_file() and not any(part in ignore_list for part in p.parts)]
+
+    # 2. Filter by depth if specified
+    if depth is not None:
+        files = [f for f in files if len(f.parts) <= depth]
+
+    # 3. File count cap with warning
+    if len(files) > 5000:
+        console.print(f"[yellow]Warning: {len(files)} files found. This may be slow. Suggest using --scoped-only to limit output.[/yellow]")
+
+    files.sort()
 
     for fp in files:
         tier_num, _ = resolve_tier(str(fp), scope)
+
+        # 4. Scoped-only flag
+        if scoped_only and tier_num == 0:
+            continue
+
         label, style, block_type = tier_styles.get(tier_num, ("[--]", "dim", "dash"))
         bar = "\u2588" * min(tier_num, 4) if block_type == "block" else "-" * 2
         text = Text()
@@ -276,6 +306,87 @@ def export(
         console.print(" ".join(result))
     else:
         console.print(result, highlight=False)
+
+
+@app.command(name="apply-proposal")
+def apply_proposal(
+    proposal_file: str = typer.Option(
+        ".consurg/recommendations/scope-proposal.yaml",
+        "--proposal-file",
+        help="Path to scope proposal YAML file",
+    ),
+    apply: bool = typer.Option(False, "--apply", help="Write mapped values to .consurg.yaml"),
+):
+    """Map scope proposal output into Consurg scope tiers."""
+    proposal_path = Path(proposal_file)
+    if not proposal_path.exists():
+        console.print(f"[red]Proposal file not found: {proposal_path}[/red]")
+        raise typer.Exit(1)
+
+    with open(proposal_path, encoding="utf-8") as f:
+        proposal = yaml.safe_load(f) or {}
+
+    required_keys = ("include_context", "read_only", "exclude")
+    missing = [k for k in required_keys if k not in proposal]
+    if missing:
+        console.print(f"[red]Invalid proposal: missing keys: {', '.join(missing)}[/red]")
+        raise typer.Exit(1)
+
+    for key in required_keys:
+        if not isinstance(proposal.get(key), list) or not all(isinstance(x, str) for x in proposal[key]):
+            console.print(f"[red]Invalid proposal: '{key}' must be a list of strings[/red]")
+            raise typer.Exit(1)
+
+    include_context = proposal.get("include_context", [])
+    read_only = proposal.get("read_only", [])
+    exclude = proposal.get("exclude", [])
+
+    table = Table(title="Scope Proposal Mapping")
+    table.add_column("Proposal Key", style="bold")
+    table.add_column("Consurg Tier")
+    table.add_column("Count", justify="right")
+    table.add_row("include_context", "working_set (T4)", str(len(include_context)))
+    table.add_row("read_only", "reference (T3)", str(len(read_only)))
+    table.add_row("exclude", "implicit blocked (T0)", str(len(exclude)))
+    console.print(table)
+
+    if not apply:
+        console.print("[yellow]Preview only. Re-run with --apply to write .consurg.yaml[/yellow]")
+        return
+
+    data = _read_yaml() or {
+        "version": 1,
+        "scope": Path.cwd().name,
+        "active": True,
+        "reason": "",
+    }
+    data["working_set"] = include_context
+    data["reference"] = read_only
+    data.setdefault("signatures", [])
+    data.setdefault("visible", [])
+    data["reason"] = str(proposal.get("task", data.get("reason", "")))
+    _write_yaml(data)
+    console.print(f"[green]Scope written to {SCOPE_FILE} from proposal[/green]")
+
+
+@app.command(name="audit-status")
+def audit_status():
+    """Show effective audit persistence configuration and storage usage."""
+    config = load_audit_config(Path.cwd())
+    stats = audit_storage_stats(config.storage_path)
+
+    table = Table(title="Audit Status")
+    table.add_column("Setting", style="bold")
+    table.add_column("Value")
+    table.add_row("enabled", "true" if config.enabled else "false")
+    table.add_row("storage_path", str(config.storage_path))
+    table.add_row("max_runs", str(config.max_runs))
+    table.add_row("max_age_days", str(config.max_age_days))
+    table.add_row("max_bytes", str(config.max_bytes))
+    table.add_row("redaction_profile", config.redaction_profile)
+    table.add_row("run_dirs", str(stats["runs"]))
+    table.add_row("storage_bytes", str(stats["bytes"]))
+    console.print(table)
 
 
 _PY_EXTENSIONS = {".py"}
@@ -593,9 +704,46 @@ def wrap(ctx: typer.Context):
     env = os.environ.copy()
     env["CONSURG_GUARD_PORT"] = str(port)
     env["CONSURG_ACTIVE"] = "1"
+    started_at = datetime.now(UTC)
+    start_ms = int(started_at.timestamp() * 1000)
+    t0 = time.perf_counter()
+    tool_name = Path(ctx.args[0]).name
+    audit_config = load_audit_config(Path.cwd(), env=env)
+    should_persist = should_audit_tool(tool_name, audit_config)
 
     try:
-        result = subprocess.run(ctx.args, env=env)
+        run_kwargs: dict = {"env": env}
+        if should_persist:
+            run_kwargs.update({"capture_output": True, "text": True, "errors": "replace"})
+        result = subprocess.run(ctx.args, **run_kwargs)
+        if should_persist:
+            if result.stdout:
+                sys.stdout.write(result.stdout)
+            if result.stderr:
+                sys.stderr.write(result.stderr)
+            duration_ms = int((time.perf_counter() - t0) * 1000)
+            trace_call = {
+                "name": tool_name,
+                "type": "tool",
+                "start_time": start_ms,
+                "duration_ms": duration_ms,
+                "success": result.returncode == 0,
+                "input": {"argv": ctx.args},
+                "output": {
+                    "returncode": result.returncode,
+                    "stdout": result.stdout or "",
+                    "stderr": result.stderr or "",
+                },
+            }
+            try:
+                persist_trace(
+                    config=audit_config,
+                    run_id=str(uuid.uuid4()),
+                    started_at=started_at,
+                    tool_calls=[trace_call],
+                )
+            except Exception:
+                console.print("[yellow]Warning: failed to persist audit trace[/yellow]")
         raise typer.Exit(result.returncode)
     except FileNotFoundError:
         console.print(f"[red]Command not found: {ctx.args[0]}[/red]")
@@ -603,6 +751,20 @@ def wrap(ctx: typer.Context):
     finally:
         server.stop()
         lockfile.remove()
+
+
+@app.command(name="scaffold-pk-agents")
+def scaffold_pk_agents_cmd(
+    force: bool = typer.Option(False, "--force", help="Overwrite existing scaffold files"),
+):
+    """Scaffold pk-agent files for scope selection and excluded-context summarization."""
+    written = scaffold_pk_agents(Path.cwd(), force=force)
+    if written:
+        console.print("[green]Scaffolded pk-agent files:[/green]")
+        for p in written:
+            console.print(f"[dim]- {p.relative_to(Path.cwd())}[/dim]")
+    else:
+        console.print("[yellow]Scaffold already exists. Use --force to overwrite.[/yellow]")
 
 
 if __name__ == "__main__":

--- a/consurg/cli.py
+++ b/consurg/cli.py
@@ -88,8 +88,9 @@ def add(
 
     existing = data.get(key, [])
     for f in files:
-        if f not in existing:
-            existing.append(f)
+        pattern = f.replace("\\", "/")
+        if pattern not in existing:
+            existing.append(pattern)
     data[key] = existing
 
     # Drift detection
@@ -157,6 +158,49 @@ def off():
     data["active"] = False
     _write_yaml(data)
     console.print("[yellow]Scope deactivated[/yellow]")
+    console.print("[dim]Hint: Run consurg clean to also unwire tools and remove .consurg.yaml[/dim]")
+
+
+@app.command()
+def clean(
+    keep_scope: bool = typer.Option(False, "--keep-scope", help="Skip removing .consurg.yaml"),
+):
+    """Deactivate scope, unwire all tools, and optionally remove .consurg.yaml."""
+    from consurg.wire import WIRERS
+
+    actions = []
+
+    # 1. Off
+    data = _read_yaml()
+    if data:
+        if data.get("active"):
+            data["active"] = False
+            _write_yaml(data)
+            actions.append("Scope deactivated")
+
+    # 2. Unwire all
+    for tool_id, wirer_cls in WIRERS.items():
+        wirer = wirer_cls()
+        if wirer.status() != "not wired":
+            result = wirer.unwire()
+            if result.success:
+                actions.append(f"Unwired {wirer.name}")
+            else:
+                actions.append(f"[red]Failed to unwire {wirer.name}: {result.message}[/red]")
+
+    # 3. Unpin
+    if not keep_scope:
+        p = _scope_path()
+        if p.exists():
+            p.unlink()
+            actions.append("Scope file (.consurg.yaml) removed")
+
+    if actions:
+        console.print("[green]Clean complete:[/green]")
+        for action in actions:
+            console.print(f" - {action}")
+    else:
+        console.print("[yellow]Nothing to clean.[/yellow]")
 
 
 @app.command()
@@ -184,7 +228,8 @@ def status():
     ]
     for label, key in tiers:
         patterns = data.get(key, [])
-        table.add_row(label, str(len(patterns)), ", ".join(patterns) if patterns else "-")
+        patterns_display = [p.replace("\\", "/") for p in patterns]
+        table.add_row(label, str(len(patterns)), ", ".join(patterns_display) if patterns_display else "-")
 
     console.print(table)
 
@@ -238,7 +283,8 @@ def map_cmd(
     files.sort()
 
     for fp in files:
-        tier_num, _ = resolve_tier(str(fp), scope)
+        fp_str = str(fp).replace("\\", "/")
+        tier_num, _ = resolve_tier(fp_str, scope)
 
         # 4. Scoped-only flag
         if scoped_only and tier_num == 0:
@@ -249,7 +295,7 @@ def map_cmd(
         text = Text()
         text.append(f"{label} ", style=style)
         text.append(bar + " ", style=style)
-        text.append(str(fp))
+        text.append(fp_str)
         tree.add(text)
 
     console.print(tree)

--- a/consurg/pk_agents.py
+++ b/consurg/pk_agents.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+AGENT_DIR = Path(".agents") / "pk-agents"
+
+SCOPE_SELECTOR_AGENT = """---
+model: anthropic:claude-sonnet-4-5
+description: "Classify repository files into include, read_only, and exclude for a specific coding request."
+timeout: 600
+maxSteps: 80
+---
+
+# Consurg Scope Selector Agent
+
+You are the scope-classification agent for Context Surgeon.
+
+## Objective
+Given a user task request, inspect this repository and propose:
+1. Files to include in active coding context (`include_context`)
+2. Files to allow as read-only (`read_only`)
+3. Files to exclude entirely (`exclude`)
+
+## Rules
+- Prioritize minimal context that still enables safe implementation.
+- Use concrete repo-relative paths (or narrow glob patterns).
+- If uncertain, classify as `read_only` before `exclude`.
+- Keep build/test/config files read-only unless edits are required.
+- Exclude generated artifacts, caches, vendor directories, and unrelated domains.
+
+## Required Workflow
+1. Read `TASK_REQUEST.md` from project root.
+2. Inventory files with `rg --files`.
+3. Use targeted code search with `rg -n` to discover call paths and dependencies.
+4. Produce `.consurg/recommendations/scope-proposal.yaml` with:
+   - `task`
+   - `include_context`
+   - `read_only`
+   - `exclude`
+   - `rationale`
+   - `risks`
+5. Also emit `.consurg/recommendations/scope-proposal.md` summarizing why each list exists.
+
+## Output Contract
+Never skip the output files. If any section is empty, write an empty list.
+"""
+
+EXCLUDED_SUMMARIZER_AGENT = """---
+model: anthropic:claude-sonnet-4-5
+description: "Summarize excluded files so implementation agents know what exists and why it is out-of-scope."
+timeout: 600
+maxSteps: 80
+---
+
+# Consurg Excluded Files Summarizer Agent
+
+You are the excluded-context review agent for Context Surgeon.
+
+## Objective
+Review files listed in `exclude` from `.consurg/recommendations/scope-proposal.yaml`.
+Create a high-signal summary for implementation agents so they:
+1. Know excluded files exist
+2. Understand how those files affect the overall system
+3. Understand why those files are unnecessary for the current task
+
+## Required Workflow
+1. Read:
+   - `TASK_REQUEST.md`
+   - `.consurg/recommendations/scope-proposal.yaml`
+2. For each excluded path (or glob), inspect enough code to understand responsibilities.
+3. Group excluded files into domains/subsystems.
+4. Write `.consurg/recommendations/excluded-context.md` with sections:
+   - `## Excluded Surface Area`
+   - `## System Influence`
+   - `## Why Excluded For This Task`
+   - `## Re-entry Triggers`
+
+## Quality Bar
+- Be concrete about boundaries and cross-module dependencies.
+- Call out any hidden risk where excluded code could still affect the task.
+- Keep the summary concise and implementation-oriented.
+"""
+
+RUNBOOK = """# Consurg pk-agent Scope Workflow
+
+This scaffold creates two agents:
+
+1. `consurg-scope-selector.pk-agent`
+2. `consurg-excluded-summarizer.pk-agent`
+
+## 1) Write the task request
+
+Create `TASK_REQUEST.md` in the project root describing the coding task.
+
+## 2) Run the scope selector
+
+```bash
+pk-agent run .agents/pk-agents/consurg-scope-selector.pk-agent
+```
+
+Expected outputs:
+- `.consurg/recommendations/scope-proposal.yaml`
+- `.consurg/recommendations/scope-proposal.md`
+
+## 3) Run the excluded summarizer
+
+```bash
+pk-agent run .agents/pk-agents/consurg-excluded-summarizer.pk-agent
+```
+
+Expected output:
+- `.consurg/recommendations/excluded-context.md`
+
+## 4) Apply results to Consurg scope
+
+Map the proposal into `.consurg.yaml`:
+- `include_context` -> `working_set`
+- `read_only` -> `reference`
+- `exclude` -> implicit Tier 0 blocked
+"""
+
+
+def scaffold_pk_agents(project_root: Path, force: bool = False) -> list[Path]:
+    agent_dir = project_root / AGENT_DIR
+    output_dir = project_root / ".consurg" / "recommendations"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    agent_dir.mkdir(parents=True, exist_ok=True)
+
+    files = {
+        agent_dir / "consurg-scope-selector.pk-agent": SCOPE_SELECTOR_AGENT,
+        agent_dir / "consurg-excluded-summarizer.pk-agent": EXCLUDED_SUMMARIZER_AGENT,
+        agent_dir / "README.md": RUNBOOK,
+    }
+
+    written: list[Path] = []
+    for path, content in files.items():
+        if path.exists() and not force:
+            continue
+        path.write_text(content, encoding="utf-8")
+        written.append(path)
+    return written

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,6 +35,7 @@ consurg/
   __init__.py             Module docstring
   __main__.py             Entry point (calls app())
   cli.py                  Typer CLI (all commands)
+  pk_agents.py            pk-agent scaffold templates + writer
   scope.py                Scope dataclass, YAML loading, narrowing, conflict detection
   enforce.py              resolve_tier() - fnmatch-based tier resolution
 
@@ -73,7 +74,7 @@ hooks/
   enforce_guard.py        Guard-aware hook (dual-path: guard -> fallback)
 
 tests/
-  test_cli.py             CLI commands (init, add, remove, on, off, status, map)
+  test_cli.py             CLI commands (init/add/remove/on/off/status/map + pk-agent scaffold/apply-proposal)
   test_cli_phase3.py      Trace and git-diff commands
   test_enforce.py         Tier resolution
   test_hook.py            Hook enforcement (allow/deny)
@@ -241,3 +242,20 @@ All other functionality uses Python stdlib:
 
 Dev:
 - `pytest>=7.0` -- testing
+
+## Audit Trace Integration
+
+Audit persistence is implemented as an opt-in path for wrapped commands.
+
+Flow:
+1. pk-agent run emits tool-call trace objects
+2. Redaction policy (`strict-v1`) sanitizes input/output fields
+3. Redacted trace persists to `.pk-agent/runs/<timestamp>/trace.json`
+4. Retention pruner enforces max age/count/bytes
+
+Trust boundaries:
+- Raw tool payloads are transient in memory
+- Persisted artifacts contain redacted-only content
+- Persistence failures are non-fatal to execution
+
+See `docs/pk-agent-audit-integration.md` for full schema and policy details.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -65,6 +65,21 @@ Pin the current scope. Currently defers to `consurg init` for creation.
 
 Remove `.consurg.yaml` from the project root.
 
+### `consurg clean [OPTIONS]`
+
+Deactivate the current scope, unwire all tools, and optionally remove `.consurg.yaml`. This is the recommended command for finishing a scoped session.
+
+| Option | Description |
+|--------|-------------|
+| `--keep-scope` | Skip removing `.consurg.yaml` (leaves scope file in an inactive state) |
+
+Equivalent to running `consurg off`, `consurg wire <tool> --unwire` for all wired tools, and `consurg unpin`.
+
+```bash
+consurg clean
+consurg clean --keep-scope
+```
+
 ## Inspection
 
 ### `consurg status`
@@ -94,9 +109,14 @@ Outputs:
 +--------------+-------+--------------------+
 ```
 
-### `consurg map`
+### `consurg map [OPTIONS]`
 
-Visualize every file in the project as a tree with tier badges.
+Visualize every file in the project as a tree with tier badges. Uses `git ls-files` for .gitignore-aware file discovery (falls back to rglob if not in a git repo).
+
+| Option | Description |
+|--------|-------------|
+| `--depth N` / `-d N` | Maximum directory depth to traverse |
+| `--scoped-only` | Only show files with tier >= 1 (hide T0 blocked entries) |
 
 ```
 auth-refactor

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -71,6 +71,17 @@ Remove `.consurg.yaml` from the project root.
 
 Show current scope status: name, active/inactive, tier counts, and patterns.
 
+### `consurg audit-status`
+
+Show effective audit configuration and current local audit storage usage.
+
+Outputs:
+- enabled/disabled state
+- storage path
+- retention settings (`max_runs`, `max_age_days`, `max_bytes`)
+- redaction profile
+- current run directory count and byte usage
+
 ```
          Scope: auth-refactor (ACTIVE)
 +--------------+-------+--------------------+
@@ -203,6 +214,65 @@ consurg wrap -- python my_script.py
 ```
 
 The wrapped command's exit code is propagated. The guard starts on a random port and cleans up automatically.
+
+## pk-agent Scope Workflow
+
+### `consurg scaffold-pk-agents [OPTIONS]`
+
+Scaffold two `pk-agent` agents for scope planning:
+- `consurg-scope-selector.pk-agent`
+- `consurg-excluded-summarizer.pk-agent`
+
+Also creates `.agents/pk-agents/README.md` with a runbook.
+
+| Option | Description |
+|--------|-------------|
+| `--force` | Overwrite existing scaffold files |
+
+```bash
+consurg scaffold-pk-agents
+consurg scaffold-pk-agents --force
+```
+
+### `consurg apply-proposal [OPTIONS]`
+
+Map a scope proposal into `.consurg.yaml`.
+
+Expected proposal keys:
+- `include_context` -> mapped to `working_set` (T4)
+- `read_only` -> mapped to `reference` (T3)
+- `exclude` -> remains implicit T0 blocked (not written as a tier list)
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--proposal-file PATH` | `.consurg/recommendations/scope-proposal.yaml` | Path to proposal YAML |
+| `--apply` | false | Write mapped values to `.consurg.yaml` (without this, preview only) |
+
+```bash
+consurg apply-proposal
+consurg apply-proposal --apply
+consurg apply-proposal --proposal-file alt/scope-proposal.yaml --apply
+```
+
+## Audit Telemetry
+
+Audit persistence is opt-in and disabled by default.
+
+### Environment variables
+
+- `CONSURG_AUDIT_PERSIST=1` -- enable persistent audit traces (default disabled)
+- `CONSURG_AUDIT_MAX_RUNS=200`
+- `CONSURG_AUDIT_MAX_AGE_DAYS=14`
+- `CONSURG_AUDIT_MAX_BYTES=104857600`
+
+### Config file
+
+- `.consurg-audit.yaml` with retention and redaction settings
+- Environment variables override file values
+
+When enabled, `consurg wrap` persists redacted traces to `.pk-agent/runs/<timestamp>/trace.json`.
+
+See `docs/pk-agent-audit-integration.md` for full contract, schema, and policy details.
 
 ## Exit Codes
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -164,6 +164,52 @@ consurg git-diff main --apply
 
 All files changed relative to `main` become T4 (working_set), their direct dependencies become T3 (reference).
 
+## Agentic Scope Planning (pk-agent)
+
+You can use a two-agent workflow to recommend scope boundaries and summarize excluded files.
+
+### 1. Scaffold the agents
+
+```bash
+consurg scaffold-pk-agents
+```
+
+If needed:
+
+```bash
+npm i -g pk-agent
+```
+
+### 2. Describe the task
+
+Create `TASK_REQUEST.md` in project root with the requested coding task.
+
+### 3. Run selector + summarizer
+
+```bash
+pk-agent run .agents/pk-agents/consurg-scope-selector.pk-agent
+pk-agent run .agents/pk-agents/consurg-excluded-summarizer.pk-agent
+```
+
+Expected outputs:
+- `.consurg/recommendations/scope-proposal.yaml`
+- `.consurg/recommendations/scope-proposal.md`
+- `.consurg/recommendations/excluded-context.md`
+
+### 4. Apply proposal to `.consurg.yaml`
+
+Preview mapping:
+
+```bash
+consurg apply-proposal
+```
+
+Write mapping:
+
+```bash
+consurg apply-proposal --apply
+```
+
 ## Next Steps
 
 - [Tier Model](tiers.md) -- Understand the 5-tier access model in depth

--- a/docs/pk-agent-audit-integration.md
+++ b/docs/pk-agent-audit-integration.md
@@ -1,0 +1,151 @@
+# pk-agent Audit Trace Integration
+
+Status: Implemented for `consurg wrap` with opt-in persistence.
+
+## Purpose
+
+Define a safe integration model for persistent pk-agent tool-call audit traces that:
+- keeps telemetry opt-in by default
+- redacts sensitive material before persistence
+- bounds local storage growth
+- remains compatible with Consurg workflows
+
+## Scope
+
+Implemented scope:
+- Data model for persisted trace files
+- Redaction policy requirements
+- Retention policy and pruning behavior
+- Config and environment interface contract
+- Acceptance criteria for current implementation
+
+Out of scope:
+- Upstream pk-agent PR merge actions
+- Cross-machine aggregation/telemetry export
+
+## Design Principles
+
+1. Opt-in telemetry only
+2. Store redacted data only (never raw secret-bearing payloads)
+3. Bounded retention with automatic pruning
+4. Best-effort persistence (never fail agent run due to trace write error)
+5. Versioned schema for forward compatibility
+
+## Interfaces
+
+### Environment variables
+
+- `CONSURG_AUDIT_PERSIST=1`: enable persistence (default disabled)
+- `CONSURG_AUDIT_MAX_RUNS=200`
+- `CONSURG_AUDIT_MAX_AGE_DAYS=14`
+- `CONSURG_AUDIT_MAX_BYTES=104857600`
+
+### Optional project config
+
+File: `.consurg-audit.yaml`
+
+```yaml
+enabled: false
+storage_path: ".pk-agent/runs"
+max_runs: 200
+max_age_days: 14
+max_bytes: 104857600
+redaction_profile: strict-v1
+include_tool_names:
+  - "*"
+exclude_tool_names: []
+```
+
+Precedence:
+1. Environment variables
+2. `.consurg-audit.yaml`
+3. Internal defaults
+
+## Trace File Schema
+
+Path:
+- `.pk-agent/runs/<timestamp>/trace.json`
+
+Schema:
+
+```json
+{
+  "schema_version": "1.0",
+  "run_id": "string",
+  "started_at": "2026-02-12T00:00:00Z",
+  "tool_calls": [
+    {
+      "name": "Read",
+      "type": "tool",
+      "start_time": 1739308800000,
+      "duration_ms": 34,
+      "success": true,
+      "redacted_input": "string",
+      "redacted_output": "string",
+      "redaction_flags": ["rule_id_1"]
+    }
+  ],
+  "retention_policy_snapshot": {
+    "max_runs": 200,
+    "max_age_days": 14,
+    "max_bytes": 104857600
+  }
+}
+```
+
+## Redaction Policy (strict-v1)
+
+Required behavior:
+- Redact known secret formats (API keys/tokens/JWT-like material)
+- Redact auth header values (`Authorization`, bearer/basic)
+- Redact structured fields by key name:
+  - `password`, `passwd`, `token`, `secret`, `authorization`, `api_key`, `private_key`, `client_secret`
+- Enforce ASCII-only output for persisted fields
+- Truncate long values with explicit truncation marker
+- If redaction fails, store sentinel value (`[REDACTION_ERROR]`) and continue run
+
+Non-goal:
+- Perfect detection for every possible obfuscation pattern in v1
+
+## Retention and Pruning
+
+Pruning should run after successful write:
+1. Delete runs older than `max_age_days`
+2. If count exceeds `max_runs`, delete oldest runs until limit met
+3. If total bytes exceeds `max_bytes`, delete oldest runs until below cap
+
+Deterministic order:
+- Sort by run timestamp directory name ascending (oldest first)
+
+## Failure Modes
+
+- Cannot write trace file:
+  - Log warning
+  - Do not fail main agent run
+- Corrupt existing trace file:
+  - Skip for parsing-based metrics
+  - Include in byte-based retention accounting if file exists
+- Missing storage directory:
+  - Create recursively
+
+## Compatibility
+
+- Existing Consurg features (`wire`, `guard`, `wrap`, `scaffold-pk-agents`, `apply-proposal`) remain unaffected when telemetry is disabled.
+- Future integration should preserve behavior with or without `.pk-agent/runs` present.
+
+## Security Considerations
+
+- Persist only redacted values, never raw payload mirrors
+- Keep retention bounded by count, age, and bytes
+- Avoid writing secrets in error messages
+
+## Acceptance Criteria
+
+1. Telemetry is disabled by default
+2. Enabling telemetry persists trace files at expected location
+3. Trace files conform to schema version `1.0`
+4. Redaction covers required key patterns and field names
+5. ASCII/truncation guarantees hold for persisted strings
+6. Retention pruning enforces age/count/byte limits
+7. Disk/permission errors never fail primary agent execution
+8. Adversarial tests verify no raw secret leakage in stored traces

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "consurg"
-version = "0.1.0"
+version = "0.1.1"
 description = "Context Surgeon - temporarily restrict AI coding agents to a declared subset of files"
 requires-python = ">=3.10"
 dependencies = [

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,69 @@
+from datetime import UTC, datetime, timedelta
+
+from consurg.audit import AuditConfig, load_audit_config, persist_trace, prune_runs
+
+
+def test_load_audit_config_from_file(tmp_path):
+    (tmp_path / ".consurg-audit.yaml").write_text(
+        "\n".join(
+            [
+                "enabled: true",
+                "storage_path: .pk-agent/runs",
+                "max_runs: 5",
+                "max_age_days: 2",
+                "max_bytes: 1024",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    cfg = load_audit_config(tmp_path, env={})
+    assert cfg.enabled is True
+    assert cfg.max_runs == 5
+    assert cfg.max_age_days == 2
+    assert cfg.max_bytes == 1024
+    assert cfg.storage_path == tmp_path / ".pk-agent" / "runs"
+
+
+def test_env_overrides_file(tmp_path):
+    (tmp_path / ".consurg-audit.yaml").write_text("max_runs: 5\n", encoding="utf-8")
+    cfg = load_audit_config(tmp_path, env={"CONSURG_AUDIT_MAX_RUNS": "12", "CONSURG_AUDIT_PERSIST": "1"})
+    assert cfg.enabled is True
+    assert cfg.max_runs == 12
+
+
+def test_prune_runs_by_max_runs(tmp_path):
+    cfg = AuditConfig(enabled=True, storage_path=tmp_path / ".pk-agent" / "runs", max_runs=2, max_age_days=999, max_bytes=99999999)
+    now = datetime.now(UTC)
+    for i in range(3):
+        persist_trace(
+            config=cfg,
+            run_id=f"run-{i}",
+            started_at=now + timedelta(seconds=i),
+            tool_calls=[],
+        )
+    run_dirs = [p for p in cfg.storage_path.iterdir() if p.is_dir()]
+    assert len(run_dirs) == 2
+
+
+def test_redaction_applies_to_sensitive_fields(tmp_path):
+    cfg = AuditConfig(enabled=True, storage_path=tmp_path / ".pk-agent" / "runs")
+    trace = persist_trace(
+        config=cfg,
+        run_id="x",
+        started_at=datetime.now(UTC),
+        tool_calls=[
+            {
+                "name": "pk-agent",
+                "type": "tool",
+                "start_time": 0,
+                "duration_ms": 1,
+                "success": True,
+                "input": {"token": "sk-secret-abc123"},
+                "output": {"Authorization": "Bearer abc.def.ghi"},
+            }
+        ],
+    )
+    payload = trace.read_text(encoding="ascii")
+    assert "sk-secret-abc123" not in payload
+    assert "abc.def.ghi" not in payload
+    assert "[REDACTED]" in payload

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ import yaml
 from typer.testing import CliRunner
 
 from consurg.cli import app
+from consurg.pk_agents import SCOPE_SELECTOR_AGENT
 
 runner = CliRunner()
 
@@ -108,6 +109,37 @@ def test_status_no_scope(in_tmp):
     assert "No scope defined" in result.output
 
 
+def test_audit_status_defaults(in_tmp):
+    result = runner.invoke(app, ["audit-status"])
+    assert result.exit_code == 0
+    assert "enabled" in result.output
+    assert "false" in result.output
+    assert "run_dirs" in result.output
+
+
+def test_audit_status_with_env_and_runs(in_tmp):
+    runs = in_tmp / ".pk-agent" / "runs" / "20260212T010203Z"
+    runs.mkdir(parents=True)
+    (runs / "trace.json").write_text('{"schema_version":"1.0"}', encoding="ascii")
+
+    result = runner.invoke(
+        app,
+        ["audit-status"],
+        env={
+            "CONSURG_AUDIT_PERSIST": "1",
+            "CONSURG_AUDIT_MAX_RUNS": "9",
+            "CONSURG_AUDIT_MAX_AGE_DAYS": "3",
+            "CONSURG_AUDIT_MAX_BYTES": "2048",
+        },
+    )
+    assert result.exit_code == 0
+    assert "true" in result.output
+    assert "9" in result.output
+    assert "3" in result.output
+    assert "2048" in result.output
+    assert "1" in result.output
+
+
 def test_on_no_scope(in_tmp):
     result = runner.invoke(app, ["on"])
     assert result.exit_code == 1
@@ -193,3 +225,162 @@ def test_unpin_removes_file(in_tmp):
 def test_unpin_no_file(in_tmp):
     result = runner.invoke(app, ["unpin"])
     assert "No scope file" in result.output
+
+
+def test_scaffold_pk_agents_creates_expected_files(in_tmp):
+    result = runner.invoke(app, ["scaffold-pk-agents"])
+    assert result.exit_code == 0
+
+    selector = in_tmp / ".agents" / "pk-agents" / "consurg-scope-selector.pk-agent"
+    summarizer = in_tmp / ".agents" / "pk-agents" / "consurg-excluded-summarizer.pk-agent"
+    runbook = in_tmp / ".agents" / "pk-agents" / "README.md"
+
+    assert selector.exists()
+    assert summarizer.exists()
+    assert runbook.exists()
+
+    assert "include_context" in selector.read_text(encoding="utf-8")
+    assert "excluded-context.md" in summarizer.read_text(encoding="utf-8")
+
+
+def test_scaffold_pk_agents_no_overwrite_without_force(in_tmp):
+    runner.invoke(app, ["scaffold-pk-agents"])
+    selector = in_tmp / ".agents" / "pk-agents" / "consurg-scope-selector.pk-agent"
+    selector.write_text("custom", encoding="utf-8")
+
+    result = runner.invoke(app, ["scaffold-pk-agents"])
+    assert result.exit_code == 0
+    assert "already exists" in result.output.lower()
+    assert selector.read_text(encoding="utf-8") == "custom"
+
+
+def test_scaffold_pk_agents_force_overwrites(in_tmp):
+    runner.invoke(app, ["scaffold-pk-agents"])
+    selector = in_tmp / ".agents" / "pk-agents" / "consurg-scope-selector.pk-agent"
+    selector.write_text("custom", encoding="utf-8")
+
+    result = runner.invoke(app, ["scaffold-pk-agents", "--force"])
+    assert result.exit_code == 0
+    assert "custom" not in selector.read_text(encoding="utf-8")
+
+
+def test_apply_proposal_preview_and_apply(in_tmp):
+    proposal_dir = in_tmp / ".consurg" / "recommendations"
+    proposal_dir.mkdir(parents=True)
+    proposal = {
+        "task": "auth bugfix",
+        "include_context": ["src/auth/login.py"],
+        "read_only": ["src/core/db.py"],
+        "exclude": ["docs/**"],
+        "rationale": [],
+        "risks": [],
+    }
+    with open(proposal_dir / "scope-proposal.yaml", "w", encoding="utf-8") as f:
+        yaml.dump(proposal, f)
+
+    preview = runner.invoke(app, ["apply-proposal"])
+    assert preview.exit_code == 0
+    assert "Preview only" in preview.output
+    assert not (in_tmp / ".consurg.yaml").exists()
+
+    applied = runner.invoke(app, ["apply-proposal", "--apply"])
+    assert applied.exit_code == 0
+    data = _read_scope(in_tmp)
+    assert data["working_set"] == ["src/auth/login.py"]
+    assert data["reference"] == ["src/core/db.py"]
+    assert data["reason"] == "auth bugfix"
+
+
+def test_apply_proposal_rejects_missing_keys(in_tmp):
+    proposal_dir = in_tmp / ".consurg" / "recommendations"
+    proposal_dir.mkdir(parents=True)
+    with open(proposal_dir / "scope-proposal.yaml", "w", encoding="utf-8") as f:
+        yaml.dump({"include_context": []}, f)
+
+    result = runner.invoke(app, ["apply-proposal", "--apply"])
+    assert result.exit_code == 1
+    assert "missing keys" in result.output
+
+
+def test_scope_selector_agent_prompt_has_required_output_keys():
+    assert "`include_context`" in SCOPE_SELECTOR_AGENT
+    assert "`read_only`" in SCOPE_SELECTOR_AGENT
+    assert "`exclude`" in SCOPE_SELECTOR_AGENT
+
+def test_map_scoped_only(in_tmp):
+    runner.invoke(app, ["init", "scope-test"])
+    (in_tmp / "scoped.py").write_text("print('scoped')")
+    (in_tmp / "blocked.py").write_text("print('blocked')")
+    runner.invoke(app, ["add", "scoped.py"])
+
+    # Standard map shows both
+    result = runner.invoke(app, ["map"])
+    assert "scoped.py" in result.output
+    assert "blocked.py" in result.output
+
+    # Scoped-only shows only scoped
+    result_scoped = runner.invoke(app, ["map", "--scoped-only"])
+    assert "scoped.py" in result_scoped.output
+    assert "blocked.py" not in result_scoped.output
+
+
+def test_map_depth_limit(in_tmp):
+    runner.invoke(app, ["init", "depth-test"])
+    (in_tmp / "level1.py").write_text("")
+    (in_tmp / "subdir").mkdir()
+    (in_tmp / "subdir" / "level2.py").write_text("")
+
+    # Depth 1 shows only level1.py
+    result = runner.invoke(app, ["map", "--depth", "1"])
+    assert "level1.py" in result.output
+    assert "level2.py" not in result.output
+
+    # No depth shows both
+    result_all = runner.invoke(app, ["map"])
+    assert "level1.py" in result_all.output
+    assert "level2.py" in result_all.output
+
+
+def test_map_file_count_cap(in_tmp):
+    runner.invoke(app, ["init", "cap-test"])
+    # Create 5000 files
+    for i in range(5000):
+        (in_tmp / f"file_{i}.txt").touch()
+
+    # Total files: 5000 + .consurg.yaml = 5001
+    result = runner.invoke(app, ["map", "--scoped-only"])
+    assert "Warning: 5001 files found" in result.output
+
+
+def test_map_git_discovery(in_tmp):
+    import subprocess
+    # Initialize git repo
+    subprocess.run(["git", "init"], cwd=in_tmp, check=True, capture_output=True)
+    (in_tmp / "tracked.py").write_text("tracked")
+    (in_tmp / "untracked.py").write_text("untracked")
+    (in_tmp / "ignored.py").write_text("ignored")
+    (in_tmp / ".gitignore").write_text("ignored.py")
+
+    # Add only some files to index
+    subprocess.run(["git", "add", "tracked.py", ".gitignore"], cwd=in_tmp, check=True, capture_output=True)
+
+    runner.invoke(app, ["init"])
+    result = runner.invoke(app, ["map"])
+
+    assert "tracked.py" in result.output
+    assert "untracked.py" in result.output
+    assert "ignored.py" not in result.output
+
+def test_map_fallback_ignore_list(in_tmp):
+    runner.invoke(app, ["init", "ignore-test"])
+    (in_tmp / "node_modules").mkdir()
+    (in_tmp / "node_modules" / "secret.py").write_text("secret")
+    (in_tmp / "dist").mkdir()
+    (in_tmp / "dist" / "build.py").write_text("build")
+    (in_tmp / "src").mkdir()
+    (in_tmp / "src" / "main.py").write_text("main")
+
+    result = runner.invoke(app, ["map"])
+    assert "src/main.py" in result.output
+    assert "node_modules/secret.py" not in result.output
+    assert "dist/build.py" not in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -72,6 +72,13 @@ def test_add_no_duplicates(in_tmp):
     assert data["working_set"] == ["src/*.py"]
 
 
+def test_add_normalizes_backslashes(in_tmp):
+    runner.invoke(app, ["init"])
+    runner.invoke(app, ["add", "src\\main.py"])
+    data = _read_scope(in_tmp)
+    assert data["working_set"] == ["src/main.py"]
+
+
 def test_add_without_init(in_tmp):
     result = runner.invoke(app, ["add", "file.py"])
     assert result.exit_code == 1
@@ -102,6 +109,19 @@ def test_status_shows_info(in_tmp):
     result = runner.invoke(app, ["status"])
     assert result.exit_code == 0
     assert "test-scope" in result.output
+
+
+def test_status_displays_forward_slashes(in_tmp):
+    runner.invoke(app, ["init"])
+    data = _read_scope(in_tmp)
+    data["working_set"] = ["src\\main.py"]
+    with open(in_tmp / ".consurg.yaml", "w") as f:
+        yaml.dump(data, f)
+
+    result = runner.invoke(app, ["status"])
+    assert result.exit_code == 0
+    assert "src/main.py" in result.output
+    assert "src\\main.py" not in result.output
 
 
 def test_status_no_scope(in_tmp):
@@ -140,9 +160,31 @@ def test_audit_status_with_env_and_runs(in_tmp):
     assert "1" in result.output
 
 
+def test_off_shows_hint(in_tmp):
+    runner.invoke(app, ["init"])
+    result = runner.invoke(app, ["off"])
+    assert "Hint: Run consurg clean" in result.output
+
+
 def test_on_no_scope(in_tmp):
     result = runner.invoke(app, ["on"])
     assert result.exit_code == 1
+
+
+# CS-011: clean
+
+def test_clean_removes_scope_file(in_tmp):
+    runner.invoke(app, ["init"])
+    result = runner.invoke(app, ["clean"])
+    assert result.exit_code == 0
+    assert not (in_tmp / ".consurg.yaml").exists()
+
+
+def test_clean_keep_scope(in_tmp):
+    runner.invoke(app, ["init"])
+    result = runner.invoke(app, ["clean", "--keep-scope"])
+    assert result.exit_code == 0
+    assert (in_tmp / ".consurg.yaml").exists()
 
 
 # CS-006: remove
@@ -178,6 +220,34 @@ def test_map_runs(in_tmp):
 def test_map_no_scope(in_tmp):
     result = runner.invoke(app, ["map"])
     assert "No scope defined" in result.output
+
+
+def test_map_scoped_only(in_tmp):
+    runner.invoke(app, ["init", "scoped-test"])
+    runner.invoke(app, ["add", "a.py"])
+    (in_tmp / "a.py").write_text("")
+    (in_tmp / "b.py").write_text("")
+
+    result_all = runner.invoke(app, ["map"])
+    assert "a.py" in result_all.output
+
+    result_scoped = runner.invoke(app, ["map", "--scoped-only"])
+    assert "a.py" in result_scoped.output
+    # b.py is T0 blocked so should be hidden
+    assert "b.py" not in result_scoped.output
+
+
+def test_map_depth_limit(in_tmp):
+    runner.invoke(app, ["init", "depth-test"])
+    runner.invoke(app, ["add", "*.py"])
+    (in_tmp / "top.py").write_text("")
+    sub = in_tmp / "sub"
+    sub.mkdir()
+    (sub / "deep.py").write_text("")
+
+    result = runner.invoke(app, ["map", "--depth", "1"])
+    assert "top.py" in result.output
+    assert "deep.py" not in result.output
 
 
 # CS-010: drift detection

--- a/tests/test_wrap.py
+++ b/tests/test_wrap.py
@@ -74,6 +74,33 @@ class TestWrapCommand:
         assert result.exit_code != 0
         assert "No scope" in result.output
 
+    def test_wrap_audit_disabled_by_default(self, scope_dir):
+        result = runner.invoke(app, ["wrap", "--", sys.executable, "-c", "print('ok')"])
+        assert result.exit_code == 0
+        assert not (scope_dir / ".pk-agent" / "runs").exists()
+
+    def test_wrap_audit_persists_redacted_trace(self, scope_dir):
+        script = "print('token=sk-1234567890abcdef')"
+        result = runner.invoke(
+            app,
+            ["wrap", "--", sys.executable, "-c", script],
+            env={"CONSURG_AUDIT_PERSIST": "1"},
+        )
+        assert result.exit_code == 0
+
+        runs_dir = scope_dir / ".pk-agent" / "runs"
+        assert runs_dir.exists()
+        trace_files = list(runs_dir.glob("*/trace.json"))
+        assert len(trace_files) == 1
+
+        payload = json.loads(trace_files[0].read_text(encoding="ascii"))
+        assert payload["schema_version"] == "1.0"
+        assert "tool_calls" in payload and len(payload["tool_calls"]) == 1
+        call = payload["tool_calls"][0]
+        assert "redacted_output" in call
+        assert "sk-1234567890abcdef" not in call["redacted_output"]
+        assert "[REDACTED]" in call["redacted_output"]
+
 
 class TestWrapLockfile:
     def test_lockfile_written_during_wrap(self, scope_dir):


### PR DESCRIPTION
This PR addresses issue #1 by improving the `consurg map` command. 

Key changes:
1.  **Efficient File Discovery**: Switched from `rglob('*')` to `git ls-files --cached --others --exclude-standard`. This automatically respects `.gitignore` and is significantly faster on large projects. Added a fallback to `rglob` with an extended ignore list (including `node_modules`, `dist`, etc.) for non-git environments.
2.  **Depth Limit**: Added a `--depth` (`-d`) option to control the traversal depth in the map output.
3.  **Scoped Visibility**: Added a `--scoped-only` flag to display only files with Tier 1 or higher (hiding blocked files).
4.  **Performance Warning**: Implemented a file count cap of 5000. If more files are found, a warning is displayed suggesting the use of `--scoped-only`.
5.  **New Tests**: Added comprehensive tests in `tests/test_cli.py` covering all new functionality, including git discovery, fallback logic, depth limits, and visibility filters.

All existing and new tests pass on the `Dev` branch.

---
*PR created automatically by Jules for task [8005992799799272944](https://jules.google.com/task/8005992799799272944) started by @kingkillery*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enable optional audit logging to track wrapped command execution with automatic redaction and configurable retention policies
  * Scaffold pk-agent templates for automated scope selection and file summarization workflows
  * Validate and apply scope proposals via new CLI commands
  * Enhanced scope mapping with depth filtering and Git-based file discovery

* **Documentation**
  * Added guides for audit integration and agentic scope planning workflows
  * Updated CLI reference documentation

* **Chores**
  * Version bump to 0.1.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->