### PR TITLE
🧹 [code health improvement] Centralize tool constants

### DIFF
--- a/consurg/constants.py
+++ b/consurg/constants.py
@@ -1,0 +1,12 @@
+"""Constants for tool names and their associated path fields."""
+
+PATH_FIELDS = {
+    "Read": "file_path",
+    "Edit": "file_path",
+    "Write": "file_path",
+    "Grep": "path",
+    "Glob": "path",
+}
+
+READ_TOOLS = {"Read", "Grep", "Glob"}
+WRITE_TOOLS = {"Edit", "Write"}

--- a/consurg/guard/server.py
+++ b/consurg/guard/server.py
@@ -14,6 +14,7 @@ import time
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import TYPE_CHECKING
 
+from consurg.constants import PATH_FIELDS, READ_TOOLS, WRITE_TOOLS
 from consurg.enforce import resolve_tier
 
 if TYPE_CHECKING:
@@ -72,7 +73,6 @@ class _GuardHandler(BaseHTTPRequestHandler):
 
         # If file_path not provided directly, try to extract from tool_input
         if not file_path:
-            from hooks.enforce import PATH_FIELDS
             path_field = PATH_FIELDS.get(tool_name, "")
             file_path = tool_input.get(path_field, "") if path_field else ""
 
@@ -83,9 +83,7 @@ class _GuardHandler(BaseHTTPRequestHandler):
         tier, label = resolve_tier(file_path, self.state.scope)
 
         # Determine if this is a write tool
-        write_tools = {"Edit", "Write"}
-        read_tools = {"Read", "Grep", "Glob"}
-        is_write = tool_name in write_tools
+        is_write = tool_name in WRITE_TOOLS
 
         # Check auto-approved patterns first
         if file_path in self.state.auto_approved:
@@ -98,7 +96,7 @@ class _GuardHandler(BaseHTTPRequestHandler):
                 return
 
         # Explorer mode: allow reads
-        if self.state.scope.explorer and tool_name in read_tools:
+        if self.state.scope.explorer and tool_name in READ_TOOLS:
             self._allow(tool_name, file_path, tier, label)
             return
 

--- a/consurg/wire/codex.py
+++ b/consurg/wire/codex.py
@@ -23,6 +23,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
+from consurg.constants import WRITE_TOOLS
 from consurg.enforce import resolve_tier
 from consurg.guard.lockfile import GuardLockfile
 from consurg.scope import load_scope
@@ -61,10 +62,9 @@ def check_access(tool_name, file_path, cwd):
         return True
 
     tier, _ = resolve_tier(file_path, scope)
-    write_tools = {"Edit", "Write"}
     if tier <= 1:
         return False
-    if tier <= 3 and tool_name in write_tools:
+    if tier <= 3 and tool_name in WRITE_TOOLS:
         return False
     return True
 

--- a/consurg/wire/gemini.py
+++ b/consurg/wire/gemini.py
@@ -23,6 +23,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
+from consurg.constants import WRITE_TOOLS
 from consurg.enforce import resolve_tier
 from consurg.guard.lockfile import GuardLockfile
 from consurg.scope import load_scope
@@ -61,10 +62,9 @@ def check_access(tool_name, file_path, cwd):
         return True
 
     tier, _ = resolve_tier(file_path, scope)
-    write_tools = {"Edit", "Write"}
     if tier <= 1:
         return False
-    if tier <= 3 and tool_name in write_tools:
+    if tier <= 3 and tool_name in WRITE_TOOLS:
         return False
     return True
 

--- a/hooks/enforce.py
+++ b/hooks/enforce.py
@@ -13,19 +13,9 @@ from pathlib import Path
 # Allow importing from the consurg package
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
+from consurg.constants import PATH_FIELDS, READ_TOOLS, WRITE_TOOLS
 from consurg.enforce import resolve_tier
 from consurg.scope import load_scope
-
-PATH_FIELDS = {
-    "Read": "file_path",
-    "Edit": "file_path",
-    "Write": "file_path",
-    "Grep": "path",
-    "Glob": "path",
-}
-
-READ_TOOLS = {"Read", "Grep", "Glob"}
-WRITE_TOOLS = {"Edit", "Write"}
 
 
 def log_violation(cwd: str, tool_name: str, target: str, label: str, scope_name: str):

--- a/hooks/enforce_guard.py
+++ b/hooks/enforce_guard.py
@@ -18,19 +18,9 @@ from pathlib import Path
 # Allow importing from the consurg package
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
+from consurg.constants import PATH_FIELDS, READ_TOOLS, WRITE_TOOLS
 from consurg.enforce import resolve_tier
 from consurg.scope import load_scope
-
-PATH_FIELDS = {
-    "Read": "file_path",
-    "Edit": "file_path",
-    "Write": "file_path",
-    "Grep": "path",
-    "Glob": "path",
-}
-
-READ_TOOLS = {"Read", "Grep", "Glob"}
-WRITE_TOOLS = {"Edit", "Write"}
 
 LOCKFILE_NAME = ".consurg-guard.lock"
 


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was duplicate hardcoded tool constants across multiple files.
💡 **Why:** Centralizing these constants in `consurg/constants.py` improves maintainability, ensures consistency, and eliminates the need for the guard server to import from a hook script.
✅ **Verification:** 98 tests passed successfully, covering core enforcement and hook logic. Manual verification of all updated files confirmed correct imports and usage.
✨ **Result:** A cleaner architecture with a single source of truth for tool definitions.


---
*PR created automatically by Jules for task [17752424392569997098](https://jules.google.com/task/17752424392569997098) started by @kingkillery*