### PR TITLE
🧪 [testing improvement] Add unit tests for wire command

### DIFF
--- a/tests/test_cli_wire.py
+++ b/tests/test_cli_wire.py
@@ -1,0 +1,55 @@
+import pytest
+from typer.testing import CliRunner
+from unittest.mock import MagicMock, patch
+from pathlib import Path
+
+from consurg.cli import app
+from consurg.wire.base import WireResult
+
+runner = CliRunner()
+
+def test_wire_success():
+    mock_wirer = MagicMock()
+    mock_wirer.wire.return_value = WireResult(success=True, message="Wired successfully", config_path=Path("/path/to/config"))
+    mock_wirer.status.return_value = "wired"
+
+    # We patch consurg.wire.WIRERS because it's imported inside the wire command
+    with patch("consurg.wire.WIRERS", {"test-tool": lambda: mock_wirer}):
+        result = runner.invoke(app, ["wire", "test-tool"])
+        assert result.exit_code == 0
+        assert "Wired successfully" in result.output
+        assert "Config: /path/to/config" in result.output
+        assert "Status: wired" in result.output
+        mock_wirer.wire.assert_called_once()
+        mock_wirer.status.assert_called_once()
+
+def test_wire_unwire_success():
+    mock_wirer = MagicMock()
+    mock_wirer.unwire.return_value = WireResult(success=True, message="Unwired successfully")
+    mock_wirer.status.return_value = "not wired"
+
+    with patch("consurg.wire.WIRERS", {"test-tool": lambda: mock_wirer}):
+        result = runner.invoke(app, ["wire", "test-tool", "--unwire"])
+        assert result.exit_code == 0
+        assert "Unwired successfully" in result.output
+        assert "Status: not wired" in result.output
+        mock_wirer.unwire.assert_called_once()
+        mock_wirer.status.assert_called_once()
+
+def test_wire_unknown_tool():
+    # Even if we don't mock WIRERS, "unknown-tool" should not be in the real WIRERS
+    result = runner.invoke(app, ["wire", "unknown-tool"])
+    assert result.exit_code == 1
+    assert "Unknown tool 'unknown-tool'" in result.output
+
+def test_wire_failure():
+    mock_wirer = MagicMock()
+    mock_wirer.wire.return_value = WireResult(success=False, message="Wiring failed")
+
+    with patch("consurg.wire.WIRERS", {"test-tool": lambda: mock_wirer}):
+        result = runner.invoke(app, ["wire", "test-tool"])
+        assert result.exit_code == 1
+        assert "Wiring failed" in result.output
+        mock_wirer.wire.assert_called_once()
+        # Should not call status on failure based on current implementation
+        mock_wirer.status.assert_not_called()


### PR DESCRIPTION
Added unit tests for the `wire` command in `consurg/cli.py` to address the untested implementation. The new test file `tests/test_cli_wire.py` covers success, unwire, unknown tool, and failure scenarios using `CliRunner` and `unittest.mock`.

---
*PR created automatically by Jules for task [12999219408826380747](https://jules.google.com/task/12999219408826380747) started by @kingkillery*