### PR TITLE
Unify scope into two outputs: enforce (guard) and render (paste-ready prompt)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,69 @@
 # Context Surgeon
 
-Temporarily restrict AI coding agents to a declared subset of files. Define what an agent can read, write, and see — enforce it in real time.
+**One scope, two outputs.** Pick the files that matter for your task — with a tier for each — and point that selection wherever you need it:
+
+1. **Enforce it** — run an AI coding agent (Claude Code, Codex, Gemini CLI, …) that can *only* see your selection. Everything else is blocked at the tool layer, live.
+2. **Render it** — compose the same selection into a paste-ready context blob for ChatGPT, Claude, or any chat LLM. Full content for working files, extracted signatures for interfaces, nothing for the rest.
+
+The selection is the **scope** (`.consurg.yaml`): a temporary, tiered boundary around the files that matter. Demote a file to signatures-only and it *both* hides its implementation from the live agent *and* shrinks to type stubs in the pasted prompt.
+
+## Install
+
+```bash
+git clone https://github.com/kingkillery/consurg.git
+cd consurg
+pip install -e .
+
+consurg --help
+```
+
+**Requirements:** Python 3.10+. Dependencies: `typer`, `rich`, `pyyaml` (installed automatically).
+
+## Quick Start
+
+### 1. Pick your files
+
+```bash
+cd your-project
+consurg pick
+```
+
+Opens a browser UI listing every file in the repo. Set each file's tier:
+
+| Toggle | Tier | Live agent gets | Pasted prompt gets |
+|--------|------|-----------------|--------------------|
+| **RW** | T4 | read + write | full content |
+| **RO** | T3 | read only | full content |
+| **SIG** | T2 | signatures only | extracted function/class signatures |
+| **OFF** | T0 | nothing | nothing |
+
+Token counts update live per file and in total.
+
+### 2a. …then paste it into ChatGPT
+
+In the UI: add optional task instructions, choose markdown/xml/plain, hit **Copy prompt**. Or from the CLI once a scope is saved:
+
+```bash
+consurg copy                        # print the rendered context
+consurg copy --clip                 # straight to clipboard
+consurg copy -f xml -t "fix login"  # xml format, task prepended
+```
+
+### 2b. …or run an agent inside it
+
+Hit **Save scope** in the UI (writes `.consurg.yaml`), then:
+
+```bash
+consurg run claude "fix the auth bug"
+```
+
+One command: wires Claude Code's hooks, starts a headless guard, launches the tool, unwires and cleans up when it exits. The agent physically cannot read or edit anything outside your selection — a blocked file returns a structured denial, not silence.
+
+Works with `claude`, `codex`, `gemini`, `droid`, `pk-agent`, or any command (guard-only if there's no wirer for it).
+
+### Watching it live (optional)
+
+Prefer to approve boundary crossings interactively? Run the guard TUI in a second terminal instead:
 
 ```
 Terminal 1: consurg guard -i          Terminal 2: claude "fix auth bug"
@@ -20,77 +83,13 @@ Terminal 1: consurg guard -i          Terminal 2: claude "fix auth bug"
 +--------------------------------+
 ```
 
-## Install
-
-```bash
-# Clone and install
-git clone https://github.com/kingkillery/consurg.git
-cd consurg
-pip install -e .
-
-# Verify
-consurg --help
-```
-
-**Requirements:** Python 3.10+. No external dependencies beyond `typer`, `rich`, and `pyyaml` (installed automatically).
-
-## Quick Start
-
-### 1. Create a scope
-
-```bash
-cd your-project
-consurg init my-feature
-```
-
-This creates `.consurg.yaml` in your project root.
-
-### 2. Define access tiers
-
-```bash
-# Files the agent can read AND write (Tier 4)
-consurg add "src/auth/*.py" "tests/test_auth.py"
-
-# Files the agent can read but not write (Tier 3)
-consurg add --read "src/core/*.py" "docs/*.md"
-
-# Files the agent can see signatures only (Tier 2)
-consurg add --sig "types/*.pyi"
-```
-
-### 3. Wire to your AI tool
-
-```bash
-# Claude Code
-consurg wire claude
-
-# Or: pk-agent, droid, gemini, codex
-consurg wire gemini
-```
-
-### 4. Start the interactive guard
-
-```bash
-consurg guard -i
-```
-
-The TUI shows every file access in real time. When the agent tries to access a blocked file, you're prompted to approve or deny — without leaving your terminal.
-
-### 5. Or wrap a single command
-
-```bash
-consurg wrap -- claude "fix the auth bug in src/auth.py"
-```
-
-Starts a headless guard, runs the command with scope enforcement, cleans up when done.
-
 ## The Tier Model
 
 | Tier | Label | Permissions | Scope Key |
 |------|-------|-------------|-----------|
 | **T4** | READ-WRITE | Full read and write access | `working_set` |
 | **T3** | READ-ONLY | Can read, cannot write | `reference` |
-| **T2** | SIGNATURE | Can view function/class signatures | `signatures` |
+| **T2** | SIGNATURE | Function/class signatures only | `signatures` |
 | **T1** | EXISTENCE | Can reference by name only | `visible` |
 | **T0** | BLOCKED | No access (default for unlisted files) | _(implicit)_ |
 
@@ -119,7 +118,25 @@ dynamic_deps: []
 explorer: false
 ```
 
+You can edit this by hand, build it in the picker UI, or generate it:
+
+```bash
+consurg trace src/main.py --depth 1   # scope from the import graph
+consurg git-diff                      # scope from changed files
+consurg add "src/auth/*.py"           # add patterns directly (--read, --sig)
+```
+
 ## All Commands
+
+### The daily three
+
+| Command | Purpose |
+|---------|---------|
+| `consurg pick` | Browser UI: set per-file tiers, copy a prompt, save the scope |
+| `consurg copy [--clip] [-f FMT] [-t TASK]` | Render the scope as a paste-ready prompt (markdown, xml, plain) |
+| `consurg run TOOL [ARGS...]` | Wire + guard + launch a tool under the scope, clean up on exit |
+
+### Scope management
 
 | Command | Purpose |
 |---------|---------|
@@ -127,55 +144,70 @@ explorer: false
 | `consurg add FILES [--read] [--sig]` | Add patterns to a tier |
 | `consurg remove FILES` | Remove patterns from all tiers |
 | `consurg on` / `off` | Activate or deactivate scope |
-| `consurg status` | Show tier counts and patterns |
-| `consurg audit-status` | Show effective audit config and local audit storage usage |
-| `consurg clean [--keep-scope]` | Deactivate scope, unwire all tools, and remove scope file |
+| `consurg status` | Show tier counts, patterns, and wired tools |
 | `consurg map [--scoped-only] [--depth N]` | Visualize files as a tree with tier badges |
 | `consurg trace ENTRIES [--depth N] [--apply]` | Build scope from dependency graph |
 | `consurg git-diff [BASE] [--apply]` | Build scope from branch diff |
-| `consurg export --format FMT` | Export as claude, cursor, aider, or generic |
-| `consurg guard [-i] [--port N] [--no-tui]` | Start interactive scope firewall |
-| `consurg wire TOOL [--unwire]` | Auto-configure hooks for a tool |
-| `consurg wrap -- CMD [ARGS]` | Run command with embedded scope enforcement |
-| `consurg scaffold-pk-agents [--force]` | Create pk-agent scope selector + excluded-context summarizer |
-| `consurg apply-proposal [--proposal-file PATH] [--apply]` | Map scope-proposal output into `.consurg.yaml` |
 | `consurg pin` / `unpin` | Save or remove scope file |
+| `consurg clean [--keep-scope]` | Deactivate scope, unwire all tools, remove scope file |
+
+### Advanced / plumbing
+
+| Command | Purpose |
+|---------|---------|
+| `consurg guard [-i] [--port N] [--no-tui]` | Start the interactive scope firewall manually |
+| `consurg wire TOOL [--unwire]` | Manually configure hooks for a tool (`run` does this for you) |
+| `consurg wrap -- CMD [ARGS]` | Run a command under a headless guard (no wiring) |
+| `consurg export --format FMT` | Export scope *rules* as claude, cursor, aider, or generic |
+| `consurg file-context [--print]` | Legacy flat file picker (superseded by `pick`) |
+| `consurg audit-status` | Show effective audit config and local audit storage usage |
+| `consurg scaffold-pk-agents [--force]` | Create pk-agent scope selector + excluded-context summarizer |
+| `consurg apply-proposal [--apply]` | Map scope-proposal output into `.consurg.yaml` |
 
 ## Supported Tools
 
-| Tool | Wire Method | Command |
-|------|-------------|---------|
-| **Claude Code** | PreToolUse hook in `.claude/hooks.json` | `consurg wire claude` |
-| **pk-agent** | `tool:start` hook in `.pk-agent/hooks.json` | `consurg wire pk-agent` |
-| **PuzlD AI (droid)** | Trusted dirs in `~/.puzldai/trusted-dirs.json` | `consurg wire droid` |
-| **Gemini CLI** | MCP server wrapper in `~/.gemini/mcp_config.json` | `consurg wire gemini` |
-| **Codex CLI** | MCP server wrapper in `~/.codex/mcp.json` | `consurg wire codex` |
+| Tool | Wire Method |
+|------|-------------|
+| **Claude Code** | PreToolUse hook in `.claude/hooks.json` |
+| **pk-agent** | `tool:start` hook in `.pk-agent/hooks.json` |
+| **PuzlD AI (droid)** | Trusted dirs in `~/.puzldai/trusted-dirs.json` |
+| **Gemini CLI** | MCP server wrapper in `~/.gemini/mcp_config.json` |
+| **Codex CLI** | MCP server wrapper in `~/.codex/mcp.json` |
 
-Unwire with `consurg wire <tool> --unwire`.
+`consurg run <tool>` wires and unwires automatically. For a persistent setup use `consurg wire <tool>` / `consurg wire <tool> --unwire`; `consurg status` shows what's currently wired.
 
-## pk-agent Scope Automation
+## Rendered Output
 
-Create the two-agent system for scope planning and excluded-context review:
+`consurg copy` (and the picker's **Copy prompt**) produce:
 
-```bash
-consurg scaffold-pk-agents
+````markdown
+# Context: auth-refactor
+
+## Task
+fix the login timeout
+
+## Files
+```
+src/auth.py      [RW]
+src/config.py    [RO]
+src/types.py     [SIG]
 ```
 
-This generates:
-- `.agents/pk-agents/consurg-scope-selector.pk-agent`
-- `.agents/pk-agents/consurg-excluded-summarizer.pk-agent`
-- `.agents/pk-agents/README.md` (runbook)
+## FILE: src/auth.py (read-write)
+...full content...
 
-Apply proposal output into Consurg tiers:
+## SIGNATURES: src/types.py (signatures)
+class User:
+def make_user(name):
+````
 
-```bash
-consurg apply-proposal --apply
-```
+Oversized files, binary files, and `never_include` matches are listed in an `## Omitted` section rather than dropped silently. Limits are configurable in `.consurg.yaml`:
 
-Install dependency if needed:
-
-```bash
-npm i -g pk-agent
+```yaml
+file_context_ui:
+  never_include: [".env", "secrets/**"]
+  max_file_bytes: 20000
+  max_total_bytes: 200000
 ```
 
 ## Documentation
@@ -199,11 +231,8 @@ Detailed documentation is in the [`docs/`](docs/) directory:
 # Install dev dependencies
 pip install -e ".[dev]"
 
-# Run tests (176 tests)
+# Run tests
 python -m pytest tests/ -v
-
-# Run a specific test file
-python -m pytest tests/test_guard.py -v
 ```
 
 ## License

--- a/consurg/cli.py
+++ b/consurg/cli.py
@@ -28,12 +28,16 @@ from consurg.enforce import resolve_tier, resolve_tier_with_pattern
 from consurg.file_context_ui import (
     IGNORED_DIR_NAMES,
     compose_prompt,
+    list_candidate_files,
     load_file_context_ui_config,
     start_ui_server,
 )
+from consurg.render import FORMATS as RENDER_FORMATS
+from consurg.render import compose_from_scope
 
 app = typer.Typer(name="consurg", help="Context Surgeon - temporarily restrict AI coding agents to a declared subset of files.")
 console = Console()
+err_console = Console(stderr=True)
 
 SCOPE_FILE = ".consurg.yaml"
 
@@ -128,6 +132,86 @@ def file_context(
         console.print(output)
         return
     start_ui_server(Path.cwd(), config, selected_files)
+
+
+@app.command()
+def pick(
+    files: list[str] | None = typer.Argument(None, help="Optional file paths to preselect as read-write."),
+):
+    """Open the scope picker UI: set per-file tiers, copy a prompt, or save the scope.
+
+    One selection, two outputs: "Save scope" writes .consurg.yaml (enforced by
+    `consurg run` / `consurg guard`); "Copy prompt" renders the same selection
+    as a paste-ready context blob for ChatGPT/Claude.
+    """
+    config = load_file_context_ui_config(Path.cwd())
+    start_ui_server(Path.cwd(), config, files or [])
+
+
+def _copy_to_clipboard(text: str) -> bool:
+    """Best-effort cross-platform clipboard copy. Returns True on success."""
+    if sys.platform == "win32":
+        commands = [["clip"]]
+    elif sys.platform == "darwin":
+        commands = [["pbcopy"]]
+    else:
+        commands = [["wl-copy"], ["xclip", "-selection", "clipboard"]]
+    for cmd in commands:
+        try:
+            proc = subprocess.run(cmd, input=text.encode("utf-8"), timeout=10)
+            if proc.returncode == 0:
+                return True
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+            continue
+    return False
+
+
+@app.command(name="copy")
+def copy_cmd(
+    fmt: str = typer.Option("markdown", "--format", "-f", help=f"Output format: {', '.join(RENDER_FORMATS)}"),
+    task: str = typer.Option("", "--task", "-t", help="Optional task/instructions to prepend."),
+    clip: bool = typer.Option(False, "--clip", "-c", help="Copy to clipboard instead of printing."),
+):
+    """Render the current scope's files into a paste-ready prompt.
+
+    T4/T3 files render as full content, T2 as extracted signatures,
+    T1 as tree entries only. Everything else is omitted.
+    """
+    if fmt not in RENDER_FORMATS:
+        console.print(f"[red]Unknown format '{fmt}'. Choose from: {', '.join(RENDER_FORMATS)}[/red]")
+        raise typer.Exit(1)
+
+    scope = load_scope(_scope_path())
+    if scope is None:
+        console.print("[red]No scope defined. Run consurg pick or consurg init[/red]")
+        raise typer.Exit(1)
+
+    cwd = Path.cwd()
+    config = load_file_context_ui_config(cwd)
+    candidates = list_candidate_files(cwd, config)
+    result = compose_from_scope(scope, cwd, candidates, limits=config, fmt=fmt, task=task)
+
+    if not result.included:
+        console.print("[yellow]Scope matched no files — nothing to render.[/yellow]")
+        raise typer.Exit(1)
+
+    if clip:
+        if _copy_to_clipboard(result.text):
+            console.print(
+                f"[green]Copied {len(result.included)} files (~{result.token_estimate:,} tokens) to clipboard.[/green]"
+            )
+        else:
+            console.print("[red]No clipboard tool available. Printing instead:[/red]")
+            sys.stdout.write(result.text)
+    else:
+        sys.stdout.write(result.text)
+        err_console.print(
+            f"[dim]{len(result.included)} files, ~{result.token_estimate:,} tokens[/dim]",
+        )
+
+    if result.skipped:
+        for path, why in result.skipped:
+            err_console.print(f"[yellow]omitted: {path} ({why})[/yellow]")
 
 
 @app.command()
@@ -360,6 +444,23 @@ def status(
         table.add_row(label, str(len(patterns)), ", ".join(patterns_display) if patterns_display else "-")
 
     console.print(table)
+
+    # Show wiring status so users never have to guess what's hooked up.
+    from consurg.wire import WIRERS
+
+    wired_rows = []
+    for tool_id, wirer_cls in WIRERS.items():
+        try:
+            wire_status = wirer_cls().status()
+        except Exception:
+            wire_status = "unknown"
+        if wire_status != "not wired":
+            wired_rows.append((tool_id, wire_status))
+    if wired_rows:
+        wired_display = ", ".join(f"{t} ({s})" for t, s in wired_rows)
+        console.print(f"Wired tools: [green]{wired_display}[/green]")
+    else:
+        console.print("Wired tools: [dim]none (use consurg run <tool> or consurg wire <tool>)[/dim]")
 
     # Show sandbox section for v2 scopes
     scope = load_scope(_scope_path())
@@ -1160,6 +1261,95 @@ def wrap(
     finally:
         server.stop()
         lockfile.remove()
+
+
+# ---------------------------------------------------------------------------
+# run command — one-shot: wire + headless guard + execute + cleanup
+# ---------------------------------------------------------------------------
+
+@app.command(
+    name="run",
+    context_settings={"allow_extra_args": True, "allow_interspersed_args": False},
+)
+def run_cmd(
+    ctx: typer.Context,
+    tool: str = typer.Argument(..., help="Tool to launch (claude, codex, gemini, droid, pk-agent, or any command)."),
+):
+    """Run a tool under the current scope in one shot.
+
+    Wires the tool's hooks if needed, starts a headless guard, launches the
+    tool, then unwires and cleans up on exit:
+
+        consurg run claude "fix the auth bug"
+    """
+    from consurg.guard.lockfile import GuardLockfile
+    from consurg.guard.server import GuardServer
+    from consurg.guard.state import GuardState
+    from consurg.wire import WIRERS
+
+    scope = load_scope(_scope_path())
+    if scope is None:
+        console.print("[red]No scope defined. Run consurg pick or consurg init[/red]")
+        raise typer.Exit(1)
+    if not scope.active:
+        console.print("[yellow]Scope is inactive. Activating for this run.[/yellow]")
+        scope.active = True
+
+    # Wire the tool if we know how, remembering whether we did it.
+    tool_key = Path(tool).name
+    wired_by_us = False
+    wirer = None
+    if tool_key in WIRERS:
+        wirer = WIRERS[tool_key]()
+        if wirer.status() != "wired":
+            result = wirer.wire()
+            if result.success:
+                wired_by_us = True
+                console.print(f"[dim]wired: {wirer.name}[/dim]")
+            else:
+                console.print(f"[yellow]Could not wire {tool_key}: {result.message}[/yellow]")
+                console.print("[yellow]Continuing — enforcement depends on the tool honoring the guard.[/yellow]")
+    else:
+        console.print(f"[dim]no wirer for '{tool_key}'; running with guard only[/dim]")
+
+    # Headless guard on a free port.
+    import socket
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        port = s.getsockname()[1]
+
+    state = GuardState(scope=scope, interactive=False, port=port)
+    lockfile = GuardLockfile()
+    lockfile.write(port=port, scope_name=scope.scope_name)
+    server = GuardServer(state)
+    server.start()
+    console.print(f"[dim]guard: headless on port {port} (scope: {scope.scope_name or 'unnamed'})[/dim]")
+
+    env = os.environ.copy()
+    env["CONSURG_GUARD_PORT"] = str(port)
+    env["CONSURG_ACTIVE"] = "1"
+
+    returncode = 1
+    try:
+        import shutil
+        executable = shutil.which(tool) or tool
+        result = subprocess.run([executable, *ctx.args], env=env)
+        returncode = result.returncode
+    except FileNotFoundError:
+        console.print(f"[red]Command not found: {tool}[/red]")
+    except KeyboardInterrupt:
+        returncode = 130
+    finally:
+        server.stop()
+        lockfile.remove()
+        if wired_by_us and wirer is not None:
+            unwire_result = wirer.unwire()
+            if unwire_result.success:
+                console.print(f"[dim]unwired: {wirer.name}[/dim]")
+            else:
+                console.print(f"[yellow]Failed to unwire {tool_key}: {unwire_result.message}[/yellow]")
+
+    raise typer.Exit(returncode)
 
 
 @app.command(name="scaffold-pk-agents")

--- a/consurg/file_context_ui.py
+++ b/consurg/file_context_ui.py
@@ -1,23 +1,28 @@
 from __future__ import annotations
 
 import json
-import socket
 import subprocess
 import threading
 import webbrowser
 from dataclasses import dataclass
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from typing import Any
 from urllib.parse import urlparse
+
 import yaml
 
-from consurg.scope import pattern_matches
+from consurg.enforce import resolve_tier
+from consurg.render import compose_from_tiers, estimate_file_tokens
+from consurg.scope import load_scope, pattern_matches
 
 
 TRUNCATION_MARKER = "\n\n[TRUNCATED: total size limit reached]\n"
 MISSING_FILE_PLACEHOLDER = "[file not found]"
 BINARY_FILE_PLACEHOLDER = "[binary file omitted]"
 LARGE_FILE_PLACEHOLDER = "[file exceeds max_file_bytes]"
+
+SCOPE_FILE = ".consurg.yaml"
 
 
 @dataclass(frozen=True)
@@ -59,7 +64,7 @@ def load_file_context_ui_config(cwd: Path) -> FileContextUIConfig:
     max_total_bytes = 200000
     hide_excluded = False
 
-    cfg_path = cwd / ".consurg.yaml"
+    cfg_path = cwd / SCOPE_FILE
     if cfg_path.exists():
         with cfg_path.open(encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
@@ -135,7 +140,54 @@ def is_denied(path: str, deny_patterns: list[str]) -> bool:
     return False
 
 
+def initial_tiers(cwd: Path, candidates: list[str]) -> tuple[dict[str, int], str]:
+    """Resolve the starting tier for each candidate from .consurg.yaml.
+
+    Returns ({path: tier}, scope_name). Files without a scope match get tier 0.
+    """
+    scope = None
+    try:
+        scope = load_scope(cwd / SCOPE_FILE)
+    except Exception:
+        scope = None
+
+    if scope is None:
+        return ({p: 0 for p in candidates}, "")
+
+    tiers = {}
+    for rel in candidates:
+        tier, _ = resolve_tier(rel, scope)
+        tiers[rel] = tier
+    return (tiers, scope.scope_name)
+
+
+def save_scope_tiers(cwd: Path, tiers: dict[str, int], scope_name: str = "") -> Path:
+    """Write explicit per-file tier lists into .consurg.yaml, preserving other keys."""
+    scope_path = cwd / SCOPE_FILE
+    data: dict = {}
+    if scope_path.exists():
+        with scope_path.open(encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+
+    data.setdefault("version", 1)
+    data["scope"] = scope_name or data.get("scope") or cwd.name
+    data.setdefault("active", True)
+    data.setdefault("reason", "")
+
+    data["working_set"] = sorted(p for p, t in tiers.items() if t == 4)
+    data["reference"] = sorted(p for p, t in tiers.items() if t == 3)
+    data["signatures"] = sorted(p for p, t in tiers.items() if t == 2)
+    # Tier 1 (existence) is not managed by the picker; preserve what's there.
+    data.setdefault("visible", [])
+    data.setdefault("dynamic_deps", [])
+
+    with scope_path.open("w", encoding="utf-8") as f:
+        yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+    return scope_path
+
+
 def compose_prompt(paths: list[str], cwd: Path, config: FileContextUIConfig, format: str = "markdown") -> str:
+    """Legacy flat-list compose: every path is rendered as full content."""
     safe_paths = []
     for path in paths:
         safe = _safe_relative_path(path, cwd)
@@ -180,11 +232,19 @@ def start_ui_server(
     preselected: list[str] | None = None,
 ):
     candidates = list_candidate_files(cwd, config)
-    selected = set(_normalize_preselected(preselected or [], cwd))
+    tiers, scope_name = initial_tiers(cwd, candidates)
 
-    handler = _make_request_handler(cwd, config, candidates, selected)
+    # Preselected files (CLI args) default to read-write if not already scoped.
+    for raw in _normalize_preselected(preselected or [], cwd):
+        rel = raw.as_posix()
+        if rel in tiers and tiers[rel] == 0:
+            tiers[rel] = 4
 
-    server = HTTPServer(("127.0.0.1", 0), handler)
+    handler = _make_request_handler(cwd, config, candidates, tiers, scope_name)
+
+    # Threading matters: browsers hold open preconnect sockets that would
+    # deadlock a single-threaded server's accept loop.
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
     port = server.server_address[1]
     server_url = f"http://127.0.0.1:{port}/"
 
@@ -209,10 +269,9 @@ def _make_request_handler(
     cwd: Path,
     config: FileContextUIConfig,
     candidates: list[str],
-    preselected: set[Path],
+    tiers: dict[str, int],
+    scope_name: str,
 ):
-    preselected_normalized = {p.as_posix() for p in preselected if p is not None}
-
     class FileContextHandler(BaseHTTPRequestHandler):
         def do_GET(self):  # noqa: N802
             parsed = urlparse(self.path)
@@ -225,42 +284,80 @@ def _make_request_handler(
 
         def do_POST(self):  # noqa: N802
             parsed = urlparse(self.path)
-            if parsed.path != "/api/compose":
+            if parsed.path == "/api/compose":
+                self._handle_compose()
+            elif parsed.path == "/api/save-scope":
+                self._handle_save_scope()
+            else:
                 self.send_error(404, "Not found")
-                return
 
+        def _read_body(self) -> dict | None:
             length = int(self.headers.get("Content-Length", "0") or "0")
             body = self.rfile.read(length).decode("utf-8")
             try:
-                payload = json.loads(body)
+                return json.loads(body)
             except json.JSONDecodeError:
                 self.send_error(400, "Invalid JSON")
+                return None
+
+        def _handle_compose(self):
+            payload = self._read_body()
+            if payload is None:
                 return
 
-            selected = payload.get("selected", [])
+            requested = _sanitize_tiers(payload.get("tiers"), cwd)
             fmt = payload.get("format", "markdown")
-            if not isinstance(selected, list):
-                selected = []
-            if fmt not in {"markdown", "plain"}:
+            if fmt not in {"markdown", "plain", "xml"}:
                 fmt = "markdown"
+            task = payload.get("task", "")
+            if not isinstance(task, str):
+                task = ""
 
-            prompt = compose_prompt(selected, cwd, config, fmt)
-            self._send_json({"prompt": prompt})
+            result = compose_from_tiers(
+                requested,
+                cwd,
+                limits=config,
+                fmt=fmt,
+                task=task,
+                scope_name=payload.get("scope_name") or scope_name,
+            )
+            self._send_json(
+                {
+                    "prompt": result.text,
+                    "tokens": result.token_estimate,
+                    "included": len(result.included),
+                    "skipped": [
+                        {"path": p, "reason": why} for p, why in result.skipped
+                    ],
+                }
+            )
+
+        def _handle_save_scope(self):
+            payload = self._read_body()
+            if payload is None:
+                return
+            requested = _sanitize_tiers(payload.get("tiers"), cwd)
+            name = payload.get("scope_name", "")
+            if not isinstance(name, str):
+                name = ""
+            path = save_scope_tiers(cwd, requested, scope_name=name.strip())
+            self._send_json({"saved": str(path)})
 
         def _files_payload(self):
             result = []
             for path in candidates:
-                if is_denied(path, config.never_include) and config.hide_excluded:
-                    if path not in preselected_normalized:
-                        continue
+                denied = is_denied(path, config.never_include)
+                if denied and config.hide_excluded and tiers.get(path, 0) == 0:
+                    continue
                 result.append(
                     {
                         "path": path,
-                        "denied": bool(is_denied(path, config.never_include)),
-                        "selected": path in preselected_normalized,
+                        "tier": tiers.get(path, 0),
+                        "denied": denied,
+                        "tokens": estimate_file_tokens(cwd / path),
                     }
                 )
-            return {"files": result}
+            return {"files": result, "scope_name": scope_name}
 
         def _send_json(self, payload: dict):
             payload_text = json.dumps(payload)
@@ -282,6 +379,27 @@ def _make_request_handler(
             return
 
     return FileContextHandler
+
+
+def _sanitize_tiers(raw: Any, cwd: Path) -> dict[str, int]:
+    """Validate a client-supplied {path: tier} map: safe paths, tiers 0-4."""
+    tiers: dict[str, int] = {}
+    if not isinstance(raw, dict):
+        return tiers
+    for path, tier in raw.items():
+        if not isinstance(path, str):
+            continue
+        try:
+            tier_int = int(tier)
+        except (TypeError, ValueError):
+            continue
+        if tier_int < 1 or tier_int > 4:
+            continue
+        safe = _safe_relative_path(path, cwd)
+        if safe is None:
+            continue
+        tiers[safe.as_posix()] = tier_int
+    return tiers
 
 
 def _render_file_block(
@@ -323,6 +441,7 @@ def _render_file_block(
     full_content = _file_prompt_block(rel_path.as_posix(), body, fmt)
     return full_content, len(full_content.encode("utf-8"))
 
+
 def _file_prompt_block(path: str, body: str, fmt: str) -> str:
     if fmt == "plain":
         return f"{path}\n{'-' * max(3, len(path))}\n{body}\n\n"
@@ -348,10 +467,10 @@ def _safe_relative_path(path: str, cwd: Path) -> Path | None:
         normalized = p.resolve(strict=False)
 
     try:
-        normalized.relative_to(cwd.resolve())
         return normalized.relative_to(cwd.resolve())
     except ValueError:
         return None
+
 
 def _normalize_preselected(raw_files: list[str], cwd: Path) -> set[Path]:
     result: set[Path] = set()
@@ -375,14 +494,12 @@ def _normalize_rel_path(path: str) -> str:
     return normalized
 
 
-
-
 def _build_html() -> str:
     return """<!doctype html>
 <html>
   <head>
     <meta charset=\"utf-8\" />
-    <title>Consurg File Context</title>
+    <title>Consurg Scope Picker</title>
     <style>
       :root {
         --bg: linear-gradient(120deg, #f5f7ff, #eef7ff);
@@ -390,6 +507,9 @@ def _build_html() -> str:
         --text: #0d1520;
         --muted: #516173;
         --accent: #2d6cdf;
+        --rw: #1d7a3d;
+        --ro: #2d6cdf;
+        --sig: #9a6b00;
       }
       body {
         margin: 0;
@@ -397,11 +517,7 @@ def _build_html() -> str:
         color: var(--text);
         background: var(--bg);
       }
-      .wrap {
-        max-width: 1000px;
-        margin: 28px auto;
-        padding: 20px;
-      }
+      .wrap { max-width: 1200px; margin: 24px auto; padding: 16px; }
       .panel {
         background: var(--card);
         border: 1px solid #cfd8ea;
@@ -409,14 +525,17 @@ def _build_html() -> str:
         box-shadow: 0 16px 40px #0f172a22;
       }
       .header {
-        padding: 18px 20px;
+        padding: 14px 20px;
         border-bottom: 1px solid #dce3f1;
-        font-weight: 700;
-        font-size: 1.1rem;
+        display: flex;
+        align-items: baseline;
+        gap: 14px;
       }
+      .header .title { font-weight: 700; font-size: 1.1rem; }
+      .header input { width: 200px; }
       .row {
         display: grid;
-        grid-template-columns: 1fr 1fr;
+        grid-template-columns: 1.2fr 1fr;
         gap: 16px;
         padding: 16px;
       }
@@ -425,63 +544,92 @@ def _build_html() -> str:
         border-radius: 12px;
         padding: 12px;
       }
-      .files-list {
-        max-height: 360px;
-        overflow: auto;
-        margin-top: 10px;
-        padding: 4px;
-      }
+      .files-list { max-height: 480px; overflow: auto; margin-top: 10px; }
       .file-row {
         display: flex;
         gap: 8px;
         align-items: center;
-        padding: 6px 2px;
+        padding: 4px 2px;
         border-bottom: 1px dashed #e8edf7;
+        font-size: 0.92rem;
       }
-      .blocked {
-        color: #b02c3e;
-        font-size: 0.88rem;
+      .file-row .path { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-family: ui-monospace, Consolas, monospace; }
+      .file-row .tokens { color: var(--muted); font-size: 0.8rem; min-width: 60px; text-align: right; }
+      .tier-btns { display: flex; gap: 2px; }
+      .tier-btns button {
+        border: 1px solid #c7d2e4;
+        background: #f6f8fc;
+        color: var(--muted);
+        border-radius: 6px;
+        padding: 2px 7px;
+        font-size: 0.78rem;
+        cursor: pointer;
       }
-      input[type='text'], select, textarea, button {
+      .tier-btns button.on-4 { background: var(--rw); color: white; border-color: transparent; }
+      .tier-btns button.on-3 { background: var(--ro); color: white; border-color: transparent; }
+      .tier-btns button.on-2 { background: var(--sig); color: white; border-color: transparent; }
+      .tier-btns button.on-0 { background: #64748b; color: white; border-color: transparent; }
+      .blocked { color: #b02c3e; font-size: 0.8rem; }
+      input[type='text'], select, textarea, button.action {
         border: 1px solid #c7d2e4;
         border-radius: 8px;
         padding: 8px;
       }
-      button {
+      button.action {
         background: var(--accent);
         border-color: transparent;
         color: white;
         cursor: pointer;
       }
-      textarea {
+      button.action.secondary { background: #475569; }
+      textarea#prompt {
         width: 100%;
-        height: 360px;
+        height: 340px;
         box-sizing: border-box;
         resize: vertical;
-        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        font-size: 0.85rem;
       }
-      .actions {
-        margin-top: 12px;
-        display: flex;
-        gap: 10px;
+      textarea#task {
+        width: 100%;
+        height: 54px;
+        box-sizing: border-box;
+        resize: vertical;
+        margin-top: 6px;
       }
-      .muted {
-        color: var(--muted);
-        font-size: 0.95rem;
-      }
-      .small {
-        font-size: 0.88rem;
-      }
+      .actions { margin-top: 12px; display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
+      .muted { color: var(--muted); font-size: 0.92rem; }
+      .small { font-size: 0.85rem; }
+      .totals { font-weight: 700; }
+      .legend span { margin-right: 10px; }
+      .bulk { margin-top: 8px; display: flex; gap: 6px; align-items: center; font-size: 0.85rem; }
     </style>
   </head>
   <body>
     <div class="wrap">
       <div class="panel">
-        <div class="header">Consurg File Context</div>
+        <div class="header">
+          <span class="title">Consurg Scope Picker</span>
+          <span class="small muted">Scope name:</span>
+          <input type="text" id="scopeName" placeholder="scope name" />
+          <span class="small muted legend">
+            <span><b style="color:var(--rw)">RW</b> full read-write</span>
+            <span><b style="color:var(--ro)">RO</b> read-only</span>
+            <span><b style="color:var(--sig)">SIG</b> signatures only</span>
+            <span><b>OFF</b> excluded</span>
+          </span>
+        </div>
         <div class="row">
           <div class="files">
-            <div class="small muted">Search and select files to include</div>
-            <input type="text" id="search" placeholder="Filter files..." />
+            <div class="small muted">Pick each file's tier — the same selection drives the agent guard and the copy-paste prompt</div>
+            <input type="text" id="search" placeholder="Filter files..." style="width:100%; box-sizing:border-box; margin-top:6px;" />
+            <div class="bulk">
+              <span class="muted">Set all filtered:</span>
+              <button data-bulk="4">RW</button>
+              <button data-bulk="3">RO</button>
+              <button data-bulk="2">SIG</button>
+              <button data-bulk="0">OFF</button>
+            </div>
             <div id="list" class="files-list"></div>
           </div>
           <div class="prompt">
@@ -489,13 +637,17 @@ def _build_html() -> str:
               Format:
               <select id="format">
                 <option value="markdown">markdown</option>
+                <option value="xml">xml</option>
                 <option value="plain">plain</option>
               </select>
+              &nbsp; <span class="totals" id="totals"></span>
             </div>
+            <textarea id="task" placeholder="Optional task / instructions to prepend..."></textarea>
             <textarea id="prompt" readonly></textarea>
             <div class="actions">
-              <button id="copy">Copy</button>
-              <button id="download">Download .txt</button>
+              <button class="action" id="copy">Copy prompt</button>
+              <button class="action" id="download">Download .txt</button>
+              <button class="action secondary" id="save">Save scope (.consurg.yaml)</button>
             </div>
             <div id="status" class="small muted"></div>
           </div>
@@ -504,72 +656,123 @@ def _build_html() -> str:
     </div>
     <script>
       let files = [];
-      let selection = new Set();
+      let tiers = {};
+      let composeTimer = null;
+
+      const TIER_LABELS = { 4: 'RW', 3: 'RO', 2: 'SIG', 0: 'OFF' };
 
       async function loadFiles() {
         const response = await fetch('/api/files');
         const payload = await response.json();
         files = payload.files || [];
+        document.getElementById('scopeName').value = payload.scope_name || '';
         files.forEach((item) => {
-          if (item.selected) {
-            selection.add(item.path);
-          }
+          tiers[item.path] = item.tier === 1 ? 0 : item.tier;
         });
         render();
-        await refreshPrompt();
+        scheduleCompose();
+      }
+
+      function filteredFiles() {
+        const q = document.getElementById('search').value.toLowerCase();
+        return files.filter((f) => f.path.toLowerCase().includes(q));
       }
 
       function render() {
-        const q = document.getElementById('search').value.toLowerCase();
         const list = document.getElementById('list');
         list.innerHTML = '';
-        files
-          .filter((f) => f.path.toLowerCase().includes(q))
-          .forEach((file) => {
-            const row = document.createElement('div');
-            row.className = 'file-row';
+        filteredFiles().forEach((file) => {
+          const row = document.createElement('div');
+          row.className = 'file-row';
 
-            const cb = document.createElement('input');
-            cb.type = 'checkbox';
-            cb.checked = selection.has(file.path);
-            cb.disabled = file.denied;
-            cb.addEventListener('change', () => {
-              if (cb.checked) {
-                selection.add(file.path);
-              } else {
-                selection.delete(file.path);
-              }
-              refreshPrompt();
-            });
-
-            const label = document.createElement('span');
-            label.textContent = file.path;
-
-            row.appendChild(cb);
-            row.appendChild(label);
-
-            if (file.denied) {
-              const blocked = document.createElement('span');
-              blocked.className = 'blocked';
-              blocked.textContent = ' blocked by policy';
-              row.appendChild(blocked);
+          const btns = document.createElement('div');
+          btns.className = 'tier-btns';
+          [4, 3, 2, 0].forEach((tier) => {
+            const b = document.createElement('button');
+            b.textContent = TIER_LABELS[tier];
+            if (tiers[file.path] === tier) {
+              b.className = 'on-' + tier;
             }
-
-            list.appendChild(row);
+            b.disabled = file.denied && tier !== 0;
+            b.addEventListener('click', () => {
+              tiers[file.path] = tier;
+              render();
+              scheduleCompose();
+            });
+            btns.appendChild(b);
           });
+
+          const label = document.createElement('span');
+          label.className = 'path';
+          label.textContent = file.path;
+          label.title = file.path;
+
+          const tokens = document.createElement('span');
+          tokens.className = 'tokens';
+          tokens.textContent = '~' + file.tokens + ' tok';
+
+          row.appendChild(btns);
+          row.appendChild(label);
+          if (file.denied) {
+            const blocked = document.createElement('span');
+            blocked.className = 'blocked';
+            blocked.textContent = 'policy';
+            row.appendChild(blocked);
+          }
+          row.appendChild(tokens);
+          list.appendChild(row);
+        });
+        updateTotals();
+      }
+
+      function selectedTiers() {
+        const out = {};
+        Object.entries(tiers).forEach(([path, tier]) => {
+          if (tier >= 2) { out[path] = tier; }
+        });
+        return out;
+      }
+
+      function updateTotals(serverTokens) {
+        const sel = selectedTiers();
+        const count = Object.keys(sel).length;
+        let est = 0;
+        files.forEach((f) => {
+          const t = sel[f.path];
+          if (t === 4 || t === 3) { est += f.tokens; }
+          else if (t === 2) { est += Math.min(f.tokens, 150); }
+        });
+        const shown = serverTokens != null ? serverTokens : est;
+        document.getElementById('totals').textContent =
+          count + ' files, ~' + shown.toLocaleString() + ' tokens';
+      }
+
+      function scheduleCompose() {
+        clearTimeout(composeTimer);
+        composeTimer = setTimeout(refreshPrompt, 250);
       }
 
       async function refreshPrompt() {
         const fmt = document.getElementById('format').value;
-        const selected = Array.from(selection);
+        const task = document.getElementById('task').value;
         const response = await fetch('/api/compose', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ selected, format: fmt })
+          body: JSON.stringify({
+            tiers: selectedTiers(),
+            format: fmt,
+            task: task,
+            scope_name: document.getElementById('scopeName').value,
+          })
         });
         const payload = await response.json();
-        const area = document.getElementById('prompt');
-        area.value = payload.prompt || '';
+        document.getElementById('prompt').value = payload.prompt || '';
+        updateTotals(payload.tokens);
+        if (payload.skipped && payload.skipped.length) {
+          setStatus('Omitted: ' + payload.skipped.map((s) => s.path + ' (' + s.reason + ')').join(', '));
+        } else {
+          setStatus('');
+        }
       }
 
       async function copyPrompt() {
@@ -588,10 +791,23 @@ def _build_html() -> str:
         const url = URL.createObjectURL(blob);
         const a = document.createElement('a');
         a.href = url;
-        a.download = 'consurg-file-context.txt';
+        a.download = 'consurg-context.txt';
         a.click();
         URL.revokeObjectURL(url);
         setStatus('Downloaded');
+      }
+
+      async function saveScope() {
+        const response = await fetch('/api/save-scope', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            tiers: selectedTiers(),
+            scope_name: document.getElementById('scopeName').value,
+          })
+        });
+        const payload = await response.json();
+        setStatus('Scope saved to ' + (payload.saved || '.consurg.yaml') + ' — ready for consurg run');
       }
 
       function setStatus(message) {
@@ -599,9 +815,21 @@ def _build_html() -> str:
       }
 
       document.getElementById('search').addEventListener('input', render);
-      document.getElementById('format').addEventListener('change', refreshPrompt);
+      document.getElementById('format').addEventListener('change', scheduleCompose);
+      document.getElementById('task').addEventListener('input', scheduleCompose);
       document.getElementById('copy').addEventListener('click', copyPrompt);
       document.getElementById('download').addEventListener('click', downloadPrompt);
+      document.getElementById('save').addEventListener('click', saveScope);
+      document.querySelectorAll('[data-bulk]').forEach((btn) => {
+        btn.addEventListener('click', () => {
+          const tier = parseInt(btn.getAttribute('data-bulk'), 10);
+          filteredFiles().forEach((f) => {
+            if (!f.denied || tier === 0) { tiers[f.path] = tier; }
+          });
+          render();
+          scheduleCompose();
+        });
+      });
 
       loadFiles();
     </script>

--- a/consurg/render.py
+++ b/consurg/render.py
@@ -1,0 +1,253 @@
+"""Render a scope's files into a copy-pasteable prompt.
+
+This is the "second output" of a scope: the same tier selection that the
+guard enforces on a live agent is composed here into a text blob for
+pasting into ChatGPT/Claude/etc.
+
+Tier semantics when rendering:
+    T4 (read-write) / T3 (read-only)  -> full file content
+    T2 (signature)                    -> extracted signatures only
+    T1 (existence)                    -> listed in the file tree, no content
+    T0 / unlisted                     -> omitted entirely
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from consurg.enforce import resolve_tier
+from consurg.scope import Scope, pattern_matches
+from consurg.trace.signatures import extract_signatures
+
+FORMATS = ("markdown", "plain", "xml")
+
+_TIER_ACCESS_LABEL = {
+    4: "read-write",
+    3: "read-only",
+    2: "signatures",
+    1: "listed",
+}
+
+_TIER_TAG = {4: "RW", 3: "RO", 2: "SIG", 1: "--"}
+
+
+@dataclass
+class RenderLimits:
+    """File-size guards for rendering. Any object with these attributes works."""
+
+    never_include: list[str] = field(default_factory=list)
+    max_file_bytes: int = 20000
+    max_total_bytes: int = 200000
+
+
+@dataclass
+class ComposeResult:
+    text: str = ""
+    token_estimate: int = 0
+    included: list[tuple[str, int]] = field(default_factory=list)
+    skipped: list[tuple[str, str]] = field(default_factory=list)
+
+
+def estimate_tokens(text: str) -> int:
+    """Cheap token estimate (~4 chars/token)."""
+    return max(0, (len(text) + 3) // 4)
+
+
+def estimate_file_tokens(path: Path) -> int:
+    try:
+        return max(0, (path.stat().st_size + 3) // 4)
+    except OSError:
+        return 0
+
+
+def compose_from_scope(
+    scope: Scope,
+    cwd: Path,
+    candidates: list[str],
+    limits: RenderLimits | None = None,
+    fmt: str = "markdown",
+    task: str = "",
+) -> ComposeResult:
+    """Resolve each candidate file's tier from the scope and render."""
+    tiers: dict[str, int] = {}
+    for rel in candidates:
+        tier, _ = resolve_tier(rel, scope)
+        if tier >= 1:
+            tiers[rel] = tier
+    return compose_from_tiers(
+        tiers,
+        cwd,
+        limits=limits,
+        fmt=fmt,
+        task=task,
+        scope_name=scope.scope_name,
+        reason=scope.reason,
+    )
+
+
+def compose_from_tiers(
+    tiers: dict[str, int],
+    cwd: Path,
+    limits: RenderLimits | None = None,
+    fmt: str = "markdown",
+    task: str = "",
+    scope_name: str = "",
+    reason: str = "",
+) -> ComposeResult:
+    """Render an explicit {relative_path: tier} map into a prompt."""
+    if fmt not in FORMATS:
+        fmt = "markdown"
+    limits = limits or RenderLimits()
+    result = ComposeResult()
+
+    ordered = sorted(
+        (p.replace("\\", "/"), t) for p, t in tiers.items() if t >= 1
+    )
+    visible = [(p, t) for p, t in ordered if not _denied(p, limits.never_include)]
+    for p, t in ordered:
+        if _denied(p, limits.never_include):
+            result.skipped.append((p, "excluded by never_include policy"))
+
+    blocks: list[str] = [_header(scope_name, reason, task, fmt)]
+    if visible:
+        blocks.append(_tree_block(visible, fmt))
+
+    total_bytes = 0
+    for rel, tier in visible:
+        if tier == 1:
+            result.included.append((rel, tier))
+            continue
+
+        body, reason_skipped = _file_body(cwd / rel, tier, limits)
+        if reason_skipped:
+            result.skipped.append((rel, reason_skipped))
+            continue
+
+        block = _content_block(rel, tier, body, fmt)
+        size = len(block.encode("utf-8"))
+        if total_bytes + size > limits.max_total_bytes:
+            result.skipped.append((rel, "total size limit reached"))
+            continue
+        blocks.append(block)
+        total_bytes += size
+        result.included.append((rel, tier))
+
+    if result.skipped:
+        blocks.append(_skipped_block(result.skipped, fmt))
+
+    result.text = "\n".join(b for b in blocks if b).rstrip() + "\n"
+    result.token_estimate = estimate_tokens(result.text)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _denied(path: str, patterns: list[str]) -> bool:
+    normalized = path.replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return any(
+        pattern_matches(normalized, str(p).replace("\\", "/").strip())
+        for p in patterns
+        if str(p).strip()
+    )
+
+
+def _header(scope_name: str, reason: str, task: str, fmt: str) -> str:
+    lines: list[str] = []
+    title = scope_name or "repository context"
+    if fmt == "xml":
+        lines.append(f'<context name="{_xml_escape(title)}">')
+        if reason:
+            lines.append(f"<reason>{_xml_escape(reason)}</reason>")
+        if task:
+            lines.append(f"<task>{_xml_escape(task)}</task>")
+    elif fmt == "plain":
+        lines.append(f"CONTEXT: {title}")
+        if reason:
+            lines.append(f"Reason: {reason}")
+        if task:
+            lines.append("")
+            lines.append(f"TASK: {task}")
+        lines.append("")
+    else:
+        lines.append(f"# Context: {title}")
+        if reason:
+            lines.append(f"> {reason}")
+        if task:
+            lines.append("")
+            lines.append("## Task")
+            lines.append(task)
+        lines.append("")
+    return "\n".join(lines)
+
+
+def _tree_block(visible: list[tuple[str, int]], fmt: str) -> str:
+    rows = [f"{p}  [{_TIER_TAG.get(t, '?')}]" for p, t in visible]
+    tree = "\n".join(rows)
+    if fmt == "xml":
+        return f"<file_tree>\n{tree}\n</file_tree>\n"
+    if fmt == "plain":
+        return f"FILES ({len(rows)}):\n{tree}\n"
+    return f"## Files\n```\n{tree}\n```\n"
+
+
+def _file_body(
+    full_path: Path, tier: int, limits: RenderLimits
+) -> tuple[str, str | None]:
+    """Return (body, skip_reason). Signature tier extracts instead of reading."""
+    if not full_path.exists():
+        return "", "file not found"
+
+    if tier == 2:
+        sigs = extract_signatures(str(full_path))
+        if sigs:
+            return "\n".join(sigs), None
+        return "[no extractable signatures]", None
+
+    try:
+        if full_path.stat().st_size > limits.max_file_bytes:
+            return "", "exceeds max_file_bytes"
+        with full_path.open("rb") as f:
+            if b"\x00" in f.read(8192):
+                return "", "binary file"
+        return full_path.read_text(encoding="utf-8", errors="replace"), None
+    except OSError:
+        return "", "unreadable"
+
+
+def _content_block(rel: str, tier: int, body: str, fmt: str) -> str:
+    access = _TIER_ACCESS_LABEL.get(tier, "read-only")
+    if fmt == "xml":
+        tag = "signatures" if tier == 2 else "file"
+        return (
+            f'<{tag} path="{_xml_escape(rel)}" access="{access}">\n'
+            f"{_xml_escape(body)}\n</{tag}>\n"
+        )
+    if fmt == "plain":
+        label = "SIGNATURES" if tier == 2 else "FILE"
+        underline = "-" * max(3, len(rel))
+        return f"{label}: {rel} ({access})\n{underline}\n{body}\n"
+    lang = Path(rel).suffix.lower().lstrip(".")
+    label = "SIGNATURES" if tier == 2 else "FILE"
+    return f"## {label}: {rel} ({access})\n```{lang}\n{body}\n```\n"
+
+
+def _skipped_block(skipped: list[tuple[str, str]], fmt: str) -> str:
+    rows = [f"{p}: {why}" for p, why in skipped]
+    body = "\n".join(rows)
+    if fmt == "xml":
+        return f"<omitted>\n{_xml_escape(body)}\n</omitted>\n"
+    if fmt == "plain":
+        return f"OMITTED:\n{body}\n"
+    return f"## Omitted\n```\n{body}\n```\n"
+
+
+def _xml_escape(text: str) -> str:
+    return (
+        text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+    )

--- a/tests/test_cli_copy_run.py
+++ b/tests/test_cli_copy_run.py
@@ -1,0 +1,105 @@
+import sys
+
+import yaml
+from typer.testing import CliRunner
+
+from consurg.cli import app
+
+runner = CliRunner()
+
+
+def _project(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "auth.py").write_text(
+        "def login(user):\n    return True\n", encoding="utf-8"
+    )
+    (tmp_path / "src" / "types.py").write_text(
+        "class User:\n    name: str\n", encoding="utf-8"
+    )
+    (tmp_path / "src" / "db.py").write_text("SECRET = 'x'\n", encoding="utf-8")
+    (tmp_path / ".consurg.yaml").write_text(
+        yaml.dump(
+            {
+                "version": 1,
+                "scope": "demo",
+                "active": True,
+                "working_set": ["src/auth.py"],
+                "signatures": ["src/types.py"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def test_copy_renders_scope(tmp_path, monkeypatch):
+    _project(tmp_path, monkeypatch)
+    result = runner.invoke(app, ["copy"])
+    assert result.exit_code == 0, result.output
+    assert "## FILE: src/auth.py (read-write)" in result.output
+    assert "def login(user):" in result.output
+    assert "## SIGNATURES: src/types.py" in result.output
+    # Implementation of signature-tier and blocked files never leaks
+    assert "SECRET" not in result.output
+
+
+def test_copy_xml_format(tmp_path, monkeypatch):
+    _project(tmp_path, monkeypatch)
+    result = runner.invoke(app, ["copy", "--format", "xml", "--task", "do the thing"])
+    assert result.exit_code == 0, result.output
+    assert '<file path="src/auth.py"' in result.output
+    assert "<task>do the thing</task>" in result.output
+
+
+def test_copy_without_scope_fails(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["copy"])
+    assert result.exit_code == 1
+    assert "No scope defined" in result.output
+
+
+def test_copy_rejects_unknown_format(tmp_path, monkeypatch):
+    _project(tmp_path, monkeypatch)
+    result = runner.invoke(app, ["copy", "--format", "docx"])
+    assert result.exit_code == 1
+    assert "Unknown format" in result.output
+
+
+def test_run_without_scope_fails(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["run", "python", "-c", "pass"])
+    assert result.exit_code == 1
+    assert "No scope defined" in result.output
+
+
+def test_run_executes_command_with_guard_env(tmp_path, monkeypatch):
+    _project(tmp_path, monkeypatch)
+    marker = tmp_path / "ran.txt"
+    code = (
+        "import os, pathlib; "
+        "pathlib.Path(r'%s').write_text("
+        "os.environ.get('CONSURG_GUARD_PORT', '') + '|' + os.environ.get('CONSURG_ACTIVE', ''))"
+    ) % str(marker)
+
+    result = runner.invoke(app, ["run", sys.executable, "-c", code])
+    assert result.exit_code == 0, result.output
+
+    port, active = marker.read_text().split("|")
+    assert port.isdigit()
+    assert active == "1"
+    # Guard lockfile is cleaned up after the run
+    assert not (tmp_path / ".consurg-guard.lock").exists()
+
+
+def test_run_propagates_exit_code(tmp_path, monkeypatch):
+    _project(tmp_path, monkeypatch)
+    result = runner.invoke(app, ["run", sys.executable, "-c", "raise SystemExit(7)"])
+    assert result.exit_code == 7
+
+
+def test_run_missing_command(tmp_path, monkeypatch):
+    _project(tmp_path, monkeypatch)
+    result = runner.invoke(app, ["run", "definitely-not-a-real-tool-xyz"])
+    assert result.exit_code == 1
+    assert "Command not found" in result.output

--- a/tests/test_cli_git_diff_error.py
+++ b/tests/test_cli_git_diff_error.py
@@ -1,8 +1,10 @@
-import sys
 import importlib
-from unittest.mock import MagicMock, patch
 import subprocess
+import sys
+from unittest.mock import MagicMock, patch
+
 import pytest
+
 
 # Define a real exception for typer.Exit
 class MockTyperExit(BaseException):
@@ -10,78 +12,126 @@ class MockTyperExit(BaseException):
         self.code = code
         super().__init__(f"Exit with code {code}")
 
-# Mock dependencies
-mock_typer = MagicMock()
-mock_typer.Exit = MockTyperExit
 
-def mock_decorator(f):
-    return f
+# Names this module replaces in sys.modules. Mock installation happens in
+# setup_module (NOT at import time) so pytest's collection of other test
+# modules never sees the mocks, and teardown_module restores the originals.
+_MOCKED_MODULE_NAMES = [
+    "typer",
+    "yaml",
+    "rich",
+    "rich.console",
+    "rich.panel",
+    "rich.table",
+    "consurg.adapters",
+    "consurg.audit",
+    "consurg.pk_agents",
+    "consurg.scope",
+    "consurg.trace",
+    "consurg.enforce",
+    "consurg.file_context_ui",
+    "consurg.render",
+]
+_original_modules: dict = {}
+_original_cli = None
+cli = None  # the consurg.cli module imported against the mocks
 
-mock_app = MagicMock()
-mock_app.command.return_value = mock_decorator
-mock_typer.Typer.return_value = mock_app
-sys.modules["typer"] = mock_typer
-
-mock_yaml = MagicMock()
-sys.modules["yaml"] = mock_yaml
-
-# Mock rich and its components
-mock_rich = MagicMock()
-mock_rich_console = MagicMock()
 
 class MockConsole:
-    def __init__(self, *args, **kwargs): pass
+    def __init__(self, *args, **kwargs):
+        pass
+
     def print(self, *args, **kwargs):
         pass
+
     def status(self, *args, **kwargs):
         return MagicMock(__enter__=lambda s: None, __exit__=lambda s, *a: None)
 
-mock_rich_console.Console = MockConsole
-sys.modules["rich"] = mock_rich
-sys.modules["rich.console"] = mock_rich_console
-sys.modules["rich.panel"] = MagicMock()
-sys.modules["rich.table"] = MagicMock()
 
-# Mock other internal dependencies
-sys.modules["consurg.adapters"] = MagicMock()
-sys.modules["consurg.audit"] = MagicMock()
-sys.modules["consurg.pk_agents"] = MagicMock()
-sys.modules["consurg.scope"] = MagicMock()
-sys.modules["consurg.trace"] = MagicMock()
-sys.modules["consurg.enforce"] = MagicMock()
-sys.modules["consurg.file_context_ui"] = MagicMock()
+def setup_module():
+    global cli, _original_cli
+    _original_modules.update(
+        {name: sys.modules.get(name) for name in _MOCKED_MODULE_NAMES}
+    )
+    _original_cli = sys.modules.get("consurg.cli")
 
-# Import the module
-if 'consurg.cli' in sys.modules:
-    del sys.modules['consurg.cli']
-import consurg.cli
+    mock_typer = MagicMock()
+    mock_typer.Exit = MockTyperExit
+
+    def mock_decorator(f):
+        return f
+
+    mock_app = MagicMock()
+    mock_app.command.return_value = mock_decorator
+    mock_typer.Typer.return_value = mock_app
+    sys.modules["typer"] = mock_typer
+
+    sys.modules["yaml"] = MagicMock()
+
+    mock_rich_console = MagicMock()
+    mock_rich_console.Console = MockConsole
+    sys.modules["rich"] = MagicMock()
+    sys.modules["rich.console"] = mock_rich_console
+    sys.modules["rich.panel"] = MagicMock()
+    sys.modules["rich.table"] = MagicMock()
+
+    sys.modules["consurg.adapters"] = MagicMock()
+    sys.modules["consurg.audit"] = MagicMock()
+    sys.modules["consurg.pk_agents"] = MagicMock()
+    sys.modules["consurg.scope"] = MagicMock()
+    sys.modules["consurg.trace"] = MagicMock()
+    sys.modules["consurg.enforce"] = MagicMock()
+    sys.modules["consurg.file_context_ui"] = MagicMock()
+    sys.modules["consurg.render"] = MagicMock()
+
+    sys.modules.pop("consurg.cli", None)
+    import consurg.cli as cli_module
+
+    cli = cli_module
+
+
+def teardown_module():
+    for name, original in _original_modules.items():
+        if original is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = original
+    sys.modules.pop("consurg.cli", None)
+    if _original_cli is not None:
+        # Reinstall the original module object, then re-execute it against the
+        # restored real dependencies (reload requires it in sys.modules).
+        sys.modules["consurg.cli"] = _original_cli
+        importlib.reload(_original_cli)
+
 
 def test_git_diff_git_not_installed(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    importlib.reload(consurg.cli)
+    importlib.reload(cli)
 
     with patch("consurg.cli.subprocess.run", side_effect=FileNotFoundError):
         # Patch typer.Exit so it actually uses the passed code
         with patch("consurg.cli.typer.Exit", side_effect=lambda code: MockTyperExit(code)):
             with pytest.raises(MockTyperExit) as excinfo:
-                consurg.cli.git_diff_cmd(base="main", apply=False)
+                cli.git_diff_cmd(base="main", apply=False)
             assert excinfo.value.code == 1
+
 
 def test_git_diff_called_process_error(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    importlib.reload(consurg.cli)
+    importlib.reload(cli)
 
     e = subprocess.CalledProcessError(1, "git")
     e.stderr = "git diff failed"
     with patch("consurg.cli.subprocess.run", side_effect=e):
         with patch("consurg.cli.typer.Exit", side_effect=lambda code: MockTyperExit(code)):
             with pytest.raises(MockTyperExit) as excinfo:
-                 consurg.cli.git_diff_cmd(base="main", apply=False)
+                cli.git_diff_cmd(base="main", apply=False)
             assert excinfo.value.code == 1
+
 
 def test_git_diff_success(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    importlib.reload(consurg.cli)
+    importlib.reload(cli)
 
     mock_result = MagicMock()
     mock_result.returncode = 0
@@ -94,6 +144,6 @@ def test_git_diff_success(tmp_path, monkeypatch):
             mock_build_graph.return_value = mock_graph
             mock_graph.classify_tiers.return_value = {"file1.py": 4, "file2.py": 3}
 
-            consurg.cli.git_diff_cmd(base="main", apply=False)
+            cli.git_diff_cmd(base="main", apply=False)
 
             mock_build_graph.assert_called_once()

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,0 +1,151 @@
+from pathlib import Path
+
+import yaml
+
+from consurg.file_context_ui import initial_tiers, save_scope_tiers
+from consurg.render import (
+    RenderLimits,
+    compose_from_scope,
+    compose_from_tiers,
+    estimate_tokens,
+)
+from consurg.scope import Scope
+
+
+def _project(tmp_path: Path) -> Path:
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "auth.py").write_text(
+        "def login(user, password):\n    return True\n", encoding="utf-8"
+    )
+    (tmp_path / "src" / "types.py").write_text(
+        "class User:\n    name: str\n\ndef make_user(name):\n    return User()\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "src" / "db.py").write_text("SECRET = 'x'\n", encoding="utf-8")
+    (tmp_path / "config.yaml").write_text("key: value\n", encoding="utf-8")
+    return tmp_path
+
+
+def test_compose_from_tiers_full_and_signatures(tmp_path):
+    cwd = _project(tmp_path)
+    tiers = {
+        "src/auth.py": 4,
+        "config.yaml": 3,
+        "src/types.py": 2,
+        "src/db.py": 1,
+    }
+    result = compose_from_tiers(tiers, cwd, scope_name="demo")
+
+    # T4/T3: full content
+    assert "## FILE: src/auth.py (read-write)" in result.text
+    assert "def login(user, password):" in result.text
+    assert "## FILE: config.yaml (read-only)" in result.text
+    assert "key: value" in result.text
+
+    # T2: signatures only, no implementation
+    assert "## SIGNATURES: src/types.py" in result.text
+    assert "class User:" in result.text
+    assert "def make_user(name):" in result.text
+    assert "return User()" not in result.text
+
+    # T1: tree listing only, no content
+    assert "src/db.py" in result.text
+    assert "SECRET" not in result.text
+
+    assert result.token_estimate == estimate_tokens(result.text)
+    assert ("src/auth.py", 4) in result.included
+    assert ("src/db.py", 1) in result.included
+
+
+def test_compose_from_tiers_respects_limits_and_denylist(tmp_path):
+    cwd = _project(tmp_path)
+    (cwd / "big.txt").write_text("x" * 500, encoding="utf-8")
+    limits = RenderLimits(never_include=["config.yaml"], max_file_bytes=100)
+
+    result = compose_from_tiers(
+        {"big.txt": 4, "config.yaml": 4, "src/auth.py": 4}, cwd, limits=limits
+    )
+    skipped_paths = {p for p, _ in result.skipped}
+    assert "big.txt" in skipped_paths
+    assert "config.yaml" in skipped_paths
+    assert "## FILE: src/auth.py" in result.text
+    assert "## Omitted" in result.text
+
+
+def test_compose_from_tiers_xml_format(tmp_path):
+    cwd = _project(tmp_path)
+    result = compose_from_tiers(
+        {"src/auth.py": 3, "src/types.py": 2}, cwd, fmt="xml", task="review this"
+    )
+    assert '<file path="src/auth.py" access="read-only">' in result.text
+    assert '<signatures path="src/types.py"' in result.text
+    assert "<task>review this</task>" in result.text
+
+
+def test_compose_from_scope_resolves_tiers(tmp_path):
+    cwd = _project(tmp_path)
+    scope = Scope(
+        scope_name="auth-work",
+        working_set=["src/auth.py"],
+        reference=["config.yaml"],
+        signatures=["src/types.py"],
+    )
+    candidates = ["src/auth.py", "src/types.py", "src/db.py", "config.yaml"]
+    result = compose_from_scope(scope, cwd, candidates)
+
+    assert "## FILE: src/auth.py (read-write)" in result.text
+    assert "## SIGNATURES: src/types.py" in result.text
+    # db.py is unlisted -> tier 0 -> fully omitted
+    assert "src/db.py" not in result.text
+
+
+def test_save_scope_tiers_roundtrip(tmp_path):
+    cwd = _project(tmp_path)
+    save_scope_tiers(
+        cwd,
+        {"src/auth.py": 4, "config.yaml": 3, "src/types.py": 2},
+        scope_name="picked",
+    )
+
+    data = yaml.safe_load((cwd / ".consurg.yaml").read_text(encoding="utf-8"))
+    assert data["scope"] == "picked"
+    assert data["working_set"] == ["src/auth.py"]
+    assert data["reference"] == ["config.yaml"]
+    assert data["signatures"] == ["src/types.py"]
+    assert data["active"] is True
+
+    # initial_tiers resolves the saved scope back onto candidates
+    tiers, name = initial_tiers(
+        cwd, ["src/auth.py", "config.yaml", "src/types.py", "src/db.py"]
+    )
+    assert name == "picked"
+    assert tiers["src/auth.py"] == 4
+    assert tiers["config.yaml"] == 3
+    assert tiers["src/types.py"] == 2
+    assert tiers["src/db.py"] == 0
+
+
+def test_save_scope_tiers_preserves_other_keys(tmp_path):
+    cwd = _project(tmp_path)
+    (cwd / ".consurg.yaml").write_text(
+        yaml.dump(
+            {
+                "version": 1,
+                "scope": "existing",
+                "active": False,
+                "reason": "why not",
+                "working_set": ["old.py"],
+                "visible": ["src/**"],
+                "file_context_ui": {"max_file_bytes": 12345},
+            }
+        ),
+        encoding="utf-8",
+    )
+    save_scope_tiers(cwd, {"src/auth.py": 4})
+
+    data = yaml.safe_load((cwd / ".consurg.yaml").read_text(encoding="utf-8"))
+    assert data["working_set"] == ["src/auth.py"]
+    assert data["scope"] == "existing"
+    assert data["reason"] == "why not"
+    assert data["visible"] == ["src/**"]
+    assert data["file_context_ui"] == {"max_file_bytes": 12345}


### PR DESCRIPTION
## Summary

One scope, two outputs. The tier selection in `.consurg.yaml` is now the single source of truth for both:

1. **Enforce** — run an agent that can only see the selection (existing guard/hook path)
2. **Render** — compose the same selection into a paste-ready context blob for ChatGPT/Claude

Previously these were disconnected: the file-context UI ignored scope tiers entirely, and export adapters only emitted *instructions about* the scope, never file contents.

## Changes

- **`consurg/render.py`** (new): renders a scope or explicit tier map into a prompt — T4/T3 as full content, T2 as extracted signatures, T1 as tree entries only. Markdown/XML/plain formats, task preamble, token estimates, and an explicit `Omitted` section (nothing dropped silently).
- **`consurg pick`**: the picker UI is now the scope editor — per-file RW/RO/SIG/OFF toggles seeded from `.consurg.yaml`, live per-file and total token counts, bulk set-filtered buttons, **Copy prompt** and **Save scope** from the same selection. Server-side path-safety validation on client tier maps.
- **`consurg copy [--clip] [-f FMT] [-t TASK]`**: render the active scope to stdout or clipboard without opening the UI.
- **`consurg run TOOL [ARGS...]`**: one-shot workflow — wires the tool if needed, starts a headless guard, launches, unwires and cleans up on exit. Propagates the tool's exit code.
- **`consurg status`** now shows which tools are wired.
- **README** rewritten around the two-output story; `pick`/`copy`/`run` are the front door, `wire`/`guard`/`wrap` moved to advanced.

## Fixes

- Picker server switched to `ThreadingHTTPServer` — the single-threaded server deadlocked on Chrome preconnect sockets (found during live browser testing).
- Missing `typing.Any` import in `file_context_ui.py`.
- `test_cli_git_diff_error.py` polluted `sys.modules` at import time, breaking test collection suite-wide on clean master; mocks moved into `setup_module`/`teardown_module` with snapshot/restore.

## Testing

- 13 new tests (`test_render.py`, `test_cli_copy_run.py`) covering tier rendering, limits/denylist, XML format, scope save/load roundtrip, copy/run CLI behavior including guard env injection and lockfile cleanup.
- Full suite: **399 passed** (the suite could not even collect before the test-pollution fix).
- Picker UI exercised end-to-end in a real browser: tier toggles, bulk actions, live token totals, compose, and save-scope verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)