### PR TITLE
Harden and redesign the local scope picker

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,168 @@
+# Consurg Scope Picker Design System
+
+## 1. Atmosphere & Identity
+
+A quiet, local-first developer workbench: precise, trustworthy, and dense enough to scan a repository without feeling crowded. The signature is a warm paper-and-ink file tree crossed by one restrained teal action color; context selection should feel like preparing a careful surgical tray, not configuring a cloud dashboard.
+
+## 2. Color
+
+### Palette
+
+| Role | Token | Value | Usage |
+|---|---|---:|---|
+| Surface/canvas | `--surface-canvas` | `#f4f2ec` | Page background |
+| Surface/primary | `--surface-primary` | `#fffdfa` | Main workspace |
+| Surface/secondary | `--surface-secondary` | `#f8f6f0` | Toolbars and grouped controls |
+| Surface/selected | `--surface-selected` | `#e5f2ed` | Selected tree rows |
+| Text/primary | `--text-primary` | `#17211e` | Headlines and body |
+| Text/secondary | `--text-secondary` | `#5f6c67` | Hints and metadata |
+| Text/tertiary | `--text-tertiary` | `#87918d` | Disabled and placeholder text |
+| Border/default | `--border-default` | `#d8d6ce` | Panels and controls |
+| Border/subtle | `--border-subtle` | `#e9e6de` | Tree rows and quiet dividers |
+| Accent/primary | `--accent-primary` | `#176b57` | Primary actions and focus |
+| Accent/hover | `--accent-hover` | `#0f5847` | Primary-action hover |
+| Accent/soft | `--accent-soft` | `#d7ebe4` | Accent-tinted backgrounds |
+| Tier/read-write | `--tier-rw` | `#176b57` | RW selection |
+| Tier/read-only | `--tier-ro` | `#315d88` | RO selection |
+| Tier/signature | `--tier-sig` | `#87651c` | Signature selection |
+| Tier/list-only | `--accent-soft` + `--text-primary` | `#d7ebe4` / `#17211e` | LIST selection |
+| Status/error | `--status-error` | `#a33c3c` | Errors and blocked policy |
+| Status/warning | `--status-warning` | `#87651c` | Omitted-file warnings |
+| Status/success | `--status-success` | `#176b57` | Confirmation |
+
+### Rules
+
+- Accent is functional only: selection, focus, and primary actions.
+- Tier colors may appear only in tier controls and their legend.
+- Surfaces and borders create hierarchy; decorative gradients and glows are not used.
+- No color outside this palette may appear in the picker.
+
+## 3. Typography
+
+### Scale
+
+| Level | Size | Weight | Line Height | Tracking | Usage |
+|---|---:|---:|---:|---:|---|
+| H1 | 24px | 680 | 1.2 | -0.02em | Product title |
+| H2 | 16px | 650 | 1.4 | -0.01em | Workspace regions |
+| Body | 15px | 400 | 1.5 | 0 | Default copy and controls |
+| Body/sm | 13px | 450 | 1.45 | 0 | Secondary information |
+| Caption | 12px | 600 | 1.35 | 0.04em | Metadata and compact labels |
+
+### Font Stack
+
+- Primary: `"Aptos", "Segoe UI Variable", "Segoe UI", system-ui, sans-serif`
+- Mono: `"Cascadia Code", "SFMono-Regular", Consolas, monospace`
+
+### Rules
+
+- File paths, token counts, and generated context use the mono stack.
+- Body text never renders below 12px.
+- Hierarchy comes from weight, spacing, and contrast rather than oversized text.
+
+## 4. Spacing & Layout
+
+### Base Unit
+
+All spacing derives from a base of **4px**.
+
+| Token | Value | Usage |
+|---|---:|---|
+| `--space-1` | 4px | Icon-to-label and compact gaps |
+| `--space-2` | 8px | Inline controls and tree rows |
+| `--space-3` | 12px | Inputs and toolbars |
+| `--space-4` | 16px | Panel padding |
+| `--space-5` | 20px | Header spacing |
+| `--space-6` | 24px | Workspace gutters |
+| `--space-8` | 32px | Page edge spacing |
+
+### Grid
+
+- Maximum content width: 1440px.
+- Desktop workspace: two columns, file tree minmax(360px, 0.95fr) and context preview minmax(420px, 1.05fr).
+- Mobile and tablet below 900px: one column with no horizontal page overflow.
+- Page margin: 16px mobile, 24px desktop.
+
+### Rules
+
+- All spacing is a multiple of 4px.
+- File depth uses a 20px indentation step because it combines a 16px control width and 4px gap.
+- The context preview remains usable at every supported breakpoint.
+
+## 5. Components
+
+### Action Button
+
+- **Structure**: semantic `button` with optional inline SVG and label.
+- **Variants**: primary, secondary, quiet.
+- **Spacing**: 8px vertical, 12px horizontal, 8px icon gap.
+- **States**: default, hover, active, focus-visible, disabled, busy.
+- **Accessibility**: visible focus ring, disabled semantics, action-specific labels.
+- **Motion**: 140ms color/opacity/transform feedback; active uses a 1px translate.
+
+### Tree Row
+
+- **Structure**: disclosure control for folders, checkbox, file/folder SVG, path label, token count, tier group.
+- **Variants**: folder, file, selected, denied, search match.
+- **Spacing**: 8px block padding and 8px gaps; 20px per nesting level.
+- **States**: expanded/collapsed, unchecked/mixed/checked, hover, focus-within, denied.
+- **Accessibility**: nested native lists with keyboard-native disclosure buttons and checkboxes; folder checkbox labels name their descendant action. Tree rerenders restore focus to the exact control that initiated the change.
+- **Motion**: only opacity and transform for load-in; disclosure honors reduced motion.
+
+### Tier Segmented Control
+
+- **Structure**: labeled group of five buttons: RW, RO, SIG, LIST, OFF.
+- **Variants**: one selected tier and denied policy state.
+- **Spacing**: 4px internal gap, compact caption scale.
+- **States**: hover, active, focus-visible, selected, disabled.
+- **Accessibility**: group label identifies the file; buttons expose `aria-pressed`.
+- **Motion**: 140ms color and transform feedback.
+
+### Status Notice
+
+- **Structure**: live text region below actions.
+- **Variants**: neutral, success, warning, error.
+- **Spacing**: 8px top margin.
+- **States**: empty or visible.
+- **Accessibility**: `role="status"`, polite live announcements; errors remain readable without color.
+- **Motion**: opacity-only appearance.
+
+### Form Control
+
+- **Structure**: visible or screen-reader label plus input, select, or textarea.
+- **Variants**: search, scope name, task, output format, prompt preview.
+- **Spacing**: 8px vertical and 12px horizontal.
+- **States**: default, hover, focus-visible, disabled, readonly.
+- **Accessibility**: every control is labeled; placeholder text is supplementary only.
+- **Motion**: 140ms border and background feedback.
+
+## 6. Motion & Interaction
+
+### Timing
+
+| Type | Duration | Easing | Usage |
+|---|---:|---|---|
+| Micro | 140ms | ease-out | Button, checkbox, focus feedback |
+| Standard | 240ms | cubic-bezier(0.16, 1, 0.3, 1) | Workspace entry and disclosure affordance |
+
+### Rules
+
+- Animate only `transform`, `opacity`, and color where no layout work is triggered.
+- Every interactive element has hover, active, focus-visible, and disabled behavior as applicable.
+- `prefers-reduced-motion: reduce` removes non-essential movement.
+- Composition is debounced and stale requests are cancelled rather than visually racing.
+- Applying a new folder payload aborts and invalidates pending composition before clearing the preview, so content from the prior folder cannot appear in the new preview.
+- Saving a wildcard-expanding scope requires explicit confirmation before the expanded scope is written.
+
+## 7. Depth & Surface
+
+### Strategy
+
+**Borders-only.** The picker uses tonal surfaces plus one-pixel borders; it does not use box shadows.
+
+| Type | Value | Usage |
+|---|---|---|
+| Default | `1px solid var(--border-default)` | Workspace, inputs, buttons |
+| Subtle | `1px solid var(--border-subtle)` | Tree rows and internal dividers |
+
+Surfaces must not use `box-shadow`; focus rings use `outline` so they remain accessibility affordances rather than visual depth.

--- a/README.md
+++ b/README.md
@@ -28,20 +28,23 @@ cd your-project
 consurg pick
 ```
 
-Opens a browser UI listing every file in the repo. Set each file's tier:
+Opens a local-only browser UI with nested native lists, disclosure buttons, and checkboxes. Start in the current repo or use **Choose folder** to switch to any local folder, then set each selected file's tier. Keyboard focus stays on the control you changed when the list updates:
 
 | Toggle | Tier | Live agent gets | Pasted prompt gets |
 |--------|------|-----------------|--------------------|
 | **RW** | T4 | read + write | full content |
 | **RO** | T3 | read only | full content |
 | **SIG** | T2 | signatures only | extracted function/class signatures |
+| **LIST** | T1 | path/name only | listed in the file tree, no content |
 | **OFF** | T0 | nothing | nothing |
 
 Token counts update live per file and in total.
 
+If saving a scope would expand wildcard entries into explicit paths, the picker explains the change and requires confirmation before saving.
+
 ### 2a. …then paste it into ChatGPT
 
-In the UI: add optional task instructions, choose markdown/xml/plain, hit **Copy prompt**. Or from the CLI once a scope is saved:
+In the UI: add optional task instructions, choose markdown/xml/plain, then hit **Copy + open ChatGPT**. The generated context is copied to your clipboard for you to paste into ChatGPT; files are never uploaded by Consurg. Or from the CLI once a scope is saved:
 
 ```bash
 consurg copy                        # print the rendered context
@@ -132,7 +135,7 @@ consurg add "src/auth/*.py"           # add patterns directly (--read, --sig)
 
 | Command | Purpose |
 |---------|---------|
-| `consurg pick` | Browser UI: set per-file tiers, copy a prompt, save the scope |
+| `consurg pick` | Local browser UI: choose a folder, check files in a tree, copy context to ChatGPT, save the scope |
 | `consurg copy [--clip] [-f FMT] [-t TASK]` | Render the scope as a paste-ready prompt (markdown, xml, plain) |
 | `consurg run TOOL [ARGS...]` | Wire + guard + launch a tool under the scope, clean up on exit |
 
@@ -178,7 +181,7 @@ consurg add "src/auth/*.py"           # add patterns directly (--read, --sig)
 
 ## Rendered Output
 
-`consurg copy` (and the picker's **Copy prompt**) produce:
+`consurg copy` (and the picker's **Copy + open ChatGPT**) produce:
 
 ````markdown
 # Context: auth-refactor

--- a/consurg/file_context_ui.html
+++ b/consurg/file_context_ui.html
@@ -1,0 +1,1107 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Choose local project files and compose paste-ready context for ChatGPT." />
+    <meta name="theme-color" content="#f4f2ec" />
+    <meta name="consurg-token" content="__CONSURG_ACCESS_TOKEN__" />
+    <title>Consurg — Context picker for ChatGPT</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --surface-canvas: #f4f2ec;
+        --surface-primary: #fffdfa;
+        --surface-secondary: #f8f6f0;
+        --surface-selected: #e5f2ed;
+        --text-primary: #17211e;
+        --text-secondary: #5f6c67;
+        --text-tertiary: #87918d;
+        --border-default: #d8d6ce;
+        --border-subtle: #e9e6de;
+        --accent-primary: #176b57;
+        --accent-hover: #0f5847;
+        --accent-soft: #d7ebe4;
+        --tier-rw: #176b57;
+        --tier-ro: #315d88;
+        --tier-sig: #87651c;
+        --status-error: #a33c3c;
+        --status-warning: #87651c;
+        --status-success: #176b57;
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --radius-sm: 6px;
+        --radius-md: 10px;
+        --radius-lg: 14px;
+        --font-sans: "Aptos", "Segoe UI Variable", "Segoe UI", system-ui, sans-serif;
+        --font-mono: "Cascadia Code", "SFMono-Regular", Consolas, monospace;
+      }
+
+      * { box-sizing: border-box; }
+
+      html { min-width: 320px; background: var(--surface-canvas); }
+
+      body {
+        min-width: 320px;
+        min-height: 100dvh;
+        margin: 0;
+        background: var(--surface-canvas);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        font-size: 15px;
+        line-height: 1.5;
+      }
+
+      button, input, select, textarea { font: inherit; }
+      button { color: inherit; }
+      svg { display: block; flex: 0 0 auto; }
+      [hidden] { display: none !important; }
+
+      .skip-link {
+        position: fixed;
+        top: var(--space-2);
+        left: var(--space-2);
+        z-index: 2;
+        padding: var(--space-2) var(--space-3);
+        border-radius: var(--radius-sm);
+        background: var(--text-primary);
+        color: var(--surface-primary);
+        transform: translateY(-160%);
+      }
+      .skip-link:focus { transform: translateY(0); }
+
+      .app-shell {
+        width: min(100% - 48px, 1440px);
+        margin: 0 auto;
+        padding: var(--space-6) 0 var(--space-8);
+      }
+
+      .app-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-4);
+        margin-bottom: var(--space-4);
+      }
+
+      .brand { display: flex; align-items: center; gap: var(--space-3); min-width: 0; }
+      .brand-mark {
+        display: grid;
+        width: 40px;
+        height: 40px;
+        place-items: center;
+        border: 1px solid var(--border-default);
+        border-radius: var(--radius-md);
+        background: var(--surface-primary);
+        color: var(--accent-primary);
+      }
+      .brand-copy { min-width: 0; }
+      h1 { margin: 0; font-size: 24px; font-weight: 680; line-height: 1.2; letter-spacing: -0.02em; }
+      .subtitle { margin: var(--space-1) 0 0; color: var(--text-secondary); font-size: 13px; }
+      .header-actions { display: flex; align-items: center; gap: var(--space-2); }
+      .local-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-1);
+        color: var(--text-secondary);
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+      }
+
+      .workspace {
+        display: grid;
+        grid-template-columns: minmax(360px, 0.95fr) minmax(420px, 1.05fr);
+        min-height: 690px;
+        overflow: hidden;
+        border: 1px solid var(--border-default);
+        border-radius: var(--radius-lg);
+        background: var(--surface-primary);
+      }
+
+      .pane { min-width: 0; }
+      .tree-pane { border-right: 1px solid var(--border-default); }
+      .pane-header {
+        min-height: 76px;
+        padding: var(--space-4);
+        border-bottom: 1px solid var(--border-default);
+        background: var(--surface-secondary);
+      }
+      .pane-heading-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-3);
+      }
+      h2 { margin: 0; font-size: 16px; font-weight: 650; line-height: 1.4; letter-spacing: -0.01em; }
+      .pane-description { margin: var(--space-1) 0 0; color: var(--text-secondary); font-size: 13px; }
+
+      .button {
+        display: inline-flex;
+        min-height: 36px;
+        align-items: center;
+        justify-content: center;
+        gap: var(--space-2);
+        padding: var(--space-2) var(--space-3);
+        border: 1px solid var(--border-default);
+        border-radius: var(--radius-sm);
+        background: var(--surface-primary);
+        color: var(--text-primary);
+        cursor: pointer;
+        font-size: 13px;
+        font-weight: 620;
+        line-height: 1.2;
+        transition: transform 140ms ease-out, background-color 140ms ease-out, border-color 140ms ease-out, color 140ms ease-out, opacity 140ms ease-out;
+      }
+      .button:hover:not(:disabled) { border-color: var(--text-tertiary); background: var(--surface-secondary); }
+      .button:active:not(:disabled) { transform: translateY(1px); }
+      .button:focus-visible,
+      .icon-button:focus-visible,
+      .tier-button:focus-visible,
+      input:focus-visible,
+      select:focus-visible,
+      textarea:focus-visible {
+        outline: 2px solid var(--accent-primary);
+        outline-offset: 2px;
+      }
+      .button:disabled { cursor: not-allowed; opacity: 0.48; }
+      .button.primary { border-color: var(--accent-primary); background: var(--accent-primary); color: var(--surface-primary); }
+      .button.primary:hover:not(:disabled) { border-color: var(--accent-hover); background: var(--accent-hover); }
+      .button.quiet { min-height: 32px; padding: var(--space-1) var(--space-2); background: transparent; }
+      .button.is-busy svg { animation: spin 800ms linear infinite; }
+
+      .tree-tools { padding: var(--space-3) var(--space-4); border-bottom: 1px solid var(--border-subtle); }
+      .search-wrap { position: relative; }
+      .search-icon { position: absolute; top: 50%; left: var(--space-3); color: var(--text-tertiary); transform: translateY(-50%); pointer-events: none; }
+      .search-input,
+      .text-input,
+      .select-input,
+      .task-input,
+      .prompt-output {
+        width: 100%;
+        border: 1px solid var(--border-default);
+        border-radius: var(--radius-sm);
+        background: var(--surface-primary);
+        color: var(--text-primary);
+        transition: background-color 140ms ease-out, border-color 140ms ease-out;
+      }
+      .search-input { min-height: 40px; padding: var(--space-2) 40px var(--space-2) 36px; }
+      .search-input::placeholder,
+      .text-input::placeholder,
+      .task-input::placeholder { color: var(--text-tertiary); }
+      .clear-search { position: absolute; top: 50%; right: var(--space-2); transform: translateY(-50%); }
+      .clear-search:active { transform: translateY(calc(-50% + 1px)); }
+
+      .bulk-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-2);
+        margin-top: var(--space-2);
+      }
+      .bulk-label { overflow: hidden; color: var(--text-secondary); font-size: 12px; text-overflow: ellipsis; white-space: nowrap; }
+      .bulk-actions { display: flex; flex: 0 0 auto; gap: var(--space-1); }
+
+      .tree-scroll { height: 522px; overflow: auto; padding: var(--space-2); scrollbar-color: var(--border-default) transparent; }
+      .tree-list, .tree-group { margin: 0; padding: 0; list-style: none; }
+      .tree-group { padding-left: var(--space-5); }
+      .tree-item { min-width: max-content; }
+      .tree-row {
+        display: grid;
+        grid-template-columns: 24px 20px 18px minmax(150px, 1fr) auto auto;
+        align-items: center;
+        min-height: 36px;
+        gap: var(--space-1);
+        padding: var(--space-1) var(--space-2);
+        border-bottom: 1px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+      }
+      .tree-row:hover { background: var(--surface-secondary); }
+      .tree-row.is-selected { background: var(--surface-selected); }
+      .tree-row.is-denied { color: var(--text-tertiary); }
+      .tree-row:focus-within { position: relative; }
+      .tree-name {
+        overflow: hidden;
+        min-width: 0;
+        font-family: var(--font-mono);
+        font-size: 13px;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .folder-row .tree-name { font-family: var(--font-sans); font-weight: 620; }
+      .tree-icon { color: var(--text-secondary); }
+      .token-count { min-width: 64px; color: var(--text-secondary); font-family: var(--font-mono); font-size: 12px; text-align: right; }
+      .policy-label { color: var(--status-error); font-size: 12px; font-weight: 600; }
+
+      .icon-button {
+        display: inline-grid;
+        width: 28px;
+        height: 28px;
+        padding: 0;
+        place-items: center;
+        border: 0;
+        border-radius: var(--radius-sm);
+        background: transparent;
+        color: var(--text-secondary);
+        cursor: pointer;
+        transition: transform 140ms ease-out, background-color 140ms ease-out, color 140ms ease-out;
+      }
+      .icon-button:hover { background: var(--accent-soft); color: var(--text-primary); }
+      .disclosure svg { transition: transform 140ms ease-out; }
+      .disclosure[aria-expanded="true"] svg { transform: rotate(90deg); }
+      .disclosure-placeholder { width: 28px; height: 28px; }
+
+      .selection-box {
+        width: 16px;
+        height: 16px;
+        margin: 0;
+        accent-color: var(--accent-primary);
+        cursor: pointer;
+      }
+      .selection-box:disabled { cursor: not-allowed; }
+
+      .tier-control {
+        display: inline-flex;
+        gap: 2px;
+        padding: 2px;
+        border: 1px solid var(--border-default);
+        border-radius: var(--radius-sm);
+        background: var(--surface-primary);
+      }
+      .tier-button {
+        min-width: 30px;
+        min-height: 24px;
+        padding: 2px var(--space-1);
+        border: 0;
+        border-radius: 4px;
+        background: transparent;
+        color: var(--text-secondary);
+        cursor: pointer;
+        font-size: 11px;
+        font-weight: 700;
+        line-height: 1;
+        transition: transform 140ms ease-out, background-color 140ms ease-out, color 140ms ease-out, opacity 140ms ease-out;
+      }
+      .tier-button:hover:not(:disabled) { background: var(--surface-secondary); color: var(--text-primary); }
+      .tier-button:active:not(:disabled) { transform: translateY(1px); }
+      .tier-button:disabled { cursor: not-allowed; opacity: 0.4; }
+      .tier-button[aria-pressed="true"][data-tier="4"] { background: var(--tier-rw); color: var(--surface-primary); }
+      .tier-button[aria-pressed="true"][data-tier="3"] { background: var(--tier-ro); color: var(--surface-primary); }
+      .tier-button[aria-pressed="true"][data-tier="2"] { background: var(--tier-sig); color: var(--surface-primary); }
+      .tier-button[aria-pressed="true"][data-tier="1"] { background: var(--accent-soft); color: var(--text-primary); }
+      .tier-button[aria-pressed="true"][data-tier="0"] { background: var(--text-secondary); color: var(--surface-primary); }
+
+      .tree-state {
+        display: grid;
+        min-height: 320px;
+        padding: var(--space-8);
+        place-items: center;
+        color: var(--text-secondary);
+        text-align: center;
+      }
+      .state-content { max-width: 320px; }
+      .state-content svg { margin: 0 auto var(--space-3); color: var(--text-tertiary); }
+      .state-title { margin: 0; color: var(--text-primary); font-weight: 650; }
+      .state-copy { margin: var(--space-1) 0 0; font-size: 13px; }
+      .skeleton { padding: var(--space-2); }
+      .skeleton-row {
+        height: 36px;
+        margin-bottom: var(--space-1);
+        border-radius: var(--radius-sm);
+        background: var(--surface-secondary);
+        animation: breathe 1.2s ease-in-out infinite alternate;
+      }
+      .skeleton-row:nth-child(2) { width: 84%; }
+      .skeleton-row:nth-child(3) { width: 92%; }
+      .skeleton-row:nth-child(4) { width: 74%; }
+
+      .preview-pane { display: grid; grid-template-rows: auto auto minmax(0, 1fr) auto; }
+      .context-meta { display: grid; grid-template-columns: minmax(0, 1fr) 150px; gap: var(--space-3); padding: var(--space-3) var(--space-4); border-bottom: 1px solid var(--border-subtle); }
+      .field { min-width: 0; }
+      .field-label { display: block; margin-bottom: var(--space-1); color: var(--text-secondary); font-size: 12px; font-weight: 600; }
+      .text-input, .select-input { min-height: 36px; padding: var(--space-2) var(--space-3); }
+      .task-field { padding: var(--space-3) var(--space-4); border-bottom: 1px solid var(--border-subtle); }
+      .task-input { min-height: 72px; padding: var(--space-2) var(--space-3); resize: vertical; }
+      .preview-field { display: flex; min-height: 0; flex-direction: column; padding: var(--space-3) var(--space-4); }
+      .preview-label-row { display: flex; align-items: center; justify-content: space-between; gap: var(--space-3); margin-bottom: var(--space-2); }
+      .totals { color: var(--text-secondary); font-family: var(--font-mono); font-size: 12px; }
+      .prompt-output {
+        min-height: 320px;
+        flex: 1 1 auto;
+        padding: var(--space-3);
+        background: var(--surface-secondary);
+        font-family: var(--font-mono);
+        font-size: 12px;
+        line-height: 1.5;
+        resize: vertical;
+        scrollbar-color: var(--border-default) transparent;
+      }
+      .prompt-output[aria-busy="true"] { opacity: 0.66; }
+
+      .preview-footer { padding: var(--space-3) var(--space-4) var(--space-4); border-top: 1px solid var(--border-default); background: var(--surface-secondary); }
+      .action-row { display: flex; align-items: center; gap: var(--space-2); flex-wrap: wrap; }
+      .action-row .primary { margin-right: auto; }
+      .status {
+        min-height: 20px;
+        margin-top: var(--space-2);
+        color: var(--text-secondary);
+        font-size: 12px;
+      }
+      .status[data-tone="success"] { color: var(--status-success); }
+      .status[data-tone="warning"] { color: var(--status-warning); }
+      .status[data-tone="error"] { color: var(--status-error); }
+
+      .privacy-note {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        margin: var(--space-3) 0 0;
+        color: var(--text-secondary);
+        font-size: 12px;
+      }
+      .privacy-note svg { color: var(--accent-primary); }
+      .visually-hidden {
+        position: absolute !important;
+        width: 1px !important;
+        height: 1px !important;
+        padding: 0 !important;
+        margin: -1px !important;
+        overflow: hidden !important;
+        clip: rect(0, 0, 0, 0) !important;
+        white-space: nowrap !important;
+        border: 0 !important;
+      }
+
+      @keyframes spin { to { transform: rotate(360deg); } }
+      @keyframes breathe { from { opacity: 0.48; } to { opacity: 1; } }
+
+      @media (max-width: 900px) {
+        .app-shell { width: min(100% - 32px, 760px); padding-top: var(--space-4); }
+        .workspace { grid-template-columns: 1fr; }
+        .tree-pane { border-right: 0; border-bottom: 1px solid var(--border-default); }
+        .tree-scroll { height: 430px; }
+        .preview-pane { min-height: 660px; }
+      }
+
+      @media (max-width: 560px) {
+        .app-shell { width: min(100% - 24px, 520px); }
+        .app-header { align-items: flex-start; }
+        .subtitle, .local-badge { display: none; }
+        .button-label-optional { display: none; }
+        .workspace { border-radius: var(--radius-md); }
+        .pane-header, .tree-tools, .context-meta, .task-field, .preview-field, .preview-footer { padding-right: var(--space-3); padding-left: var(--space-3); }
+        .context-meta { grid-template-columns: 1fr; }
+        .tree-scroll { height: 380px; }
+        .tree-row { grid-template-columns: 24px 20px 18px minmax(120px, 1fr) auto; }
+        .tree-row .token-count { display: none; }
+        .tier-control { grid-column: 4 / -1; justify-self: start; margin: var(--space-1) 0; }
+        .policy-label { grid-column: 5; }
+        .action-row .button { flex: 1 1 auto; }
+        .action-row .primary { flex-basis: 100%; margin-right: 0; }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        *, *::before, *::after { scroll-behavior: auto !important; animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; transition-duration: 0.01ms !important; }
+      }
+    </style>
+  </head>
+  <body>
+    <a class="skip-link" href="#context-preview">Skip to context preview</a>
+    <div class="app-shell">
+      <header class="app-header">
+        <div class="brand">
+          <div class="brand-mark" aria-hidden="true">
+            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M4 6.5h6l2 2H20v9.5H4z" />
+              <path d="m9 13 2 2 4-5" />
+            </svg>
+          </div>
+          <div class="brand-copy">
+            <h1>Consurg</h1>
+            <p class="subtitle">Choose exactly what ChatGPT gets to see.</p>
+          </div>
+        </div>
+        <div class="header-actions">
+          <span class="local-badge">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 3 4 6v5c0 5 3.4 8.7 8 10 4.6-1.3 8-5 8-10V6z" /><path d="m9 12 2 2 4-4" /></svg>
+            LOCAL ONLY
+          </span>
+          <button class="button" id="chooseFolder" type="button">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 6.5h7l2 2h9v10H3z" /><path d="M12 12v5M9.5 14.5h5" /></svg>
+            <span class="button-label-optional">Choose folder</span>
+          </button>
+        </div>
+      </header>
+
+      <main class="workspace" id="main">
+        <section class="pane tree-pane" aria-labelledby="files-heading">
+          <header class="pane-header">
+            <div class="pane-heading-row">
+              <div>
+                <h2 id="files-heading">Local files</h2>
+                <p class="pane-description" id="rootDescription">Loading selected folder…</p>
+              </div>
+              <span class="local-badge" id="fileCount" aria-live="polite"></span>
+            </div>
+          </header>
+
+          <div class="tree-tools">
+            <label class="visually-hidden" for="search">Filter files by path</label>
+            <div class="search-wrap">
+              <svg class="search-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><circle cx="11" cy="11" r="7" /><path d="m20 20-4-4" /></svg>
+              <input class="search-input" id="search" type="search" placeholder="Filter by file or folder…" autocomplete="off" />
+              <button class="icon-button clear-search" id="clearSearch" type="button" aria-label="Clear file filter" hidden>
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="m6 6 12 12M18 6 6 18" /></svg>
+              </button>
+            </div>
+            <div class="bulk-row">
+              <span class="bulk-label" id="bulkLabel">Select files to include as context</span>
+              <div class="bulk-actions">
+                <button class="button quiet" id="selectFiltered" type="button">Select shown</button>
+                <button class="button quiet" id="clearFiltered" type="button">Clear shown</button>
+              </div>
+            </div>
+          </div>
+
+          <div class="tree-scroll" id="treeScroll">
+            <div class="skeleton" id="treeLoading" aria-label="Loading local files" aria-busy="true">
+              <div class="skeleton-row"></div><div class="skeleton-row"></div><div class="skeleton-row"></div><div class="skeleton-row"></div>
+            </div>
+            <ul class="tree-list" id="fileTree" aria-label="Local project files" hidden></ul>
+            <div class="tree-state" id="emptyState" hidden>
+              <div class="state-content">
+                <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 6.5h7l2 2h9v10H3z" /><path d="M8 13h8" /></svg>
+                <p class="state-title" id="emptyTitle">No files found</p>
+                <p class="state-copy" id="emptyCopy">Choose a folder that contains readable project files.</p>
+              </div>
+            </div>
+            <div class="tree-state" id="treeError" role="alert" hidden>
+              <div class="state-content">
+                <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9" /><path d="M12 7v6M12 17h.01" /></svg>
+                <p class="state-title">Could not read this folder</p>
+                <p class="state-copy" id="treeErrorCopy">Try choosing it again.</p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section class="pane preview-pane" id="context-preview" aria-labelledby="preview-heading">
+          <header class="pane-header">
+            <div class="pane-heading-row">
+              <div>
+                <h2 id="preview-heading">ChatGPT context</h2>
+                <p class="pane-description">Review the exact text before copying it.</p>
+              </div>
+              <span class="totals" id="totals">0 files · ~0 tokens</span>
+            </div>
+          </header>
+
+          <div class="context-meta">
+            <div class="field">
+              <label class="field-label" for="scopeName">Context name</label>
+              <input class="text-input" id="scopeName" type="text" placeholder="e.g. auth refactor" maxlength="120" />
+            </div>
+            <div class="field">
+              <label class="field-label" for="format">Format</label>
+              <select class="select-input" id="format">
+                <option value="markdown">Markdown</option>
+                <option value="xml">XML</option>
+                <option value="plain">Plain text</option>
+              </select>
+            </div>
+          </div>
+
+          <div class="task-field">
+            <label class="field-label" for="task">Task for ChatGPT <span class="visually-hidden">(optional)</span></label>
+            <textarea class="task-input" id="task" placeholder="Optional: describe what you want ChatGPT to do with these files…"></textarea>
+          </div>
+
+          <div class="preview-field">
+            <div class="preview-label-row">
+              <label class="field-label" for="prompt">Generated context</label>
+              <span class="field-label" id="composeState">Ready</span>
+            </div>
+            <textarea class="prompt-output" id="prompt" readonly spellcheck="false" aria-describedby="privacyNote"></textarea>
+          </div>
+
+          <footer class="preview-footer">
+            <div class="action-row">
+              <button class="button primary" id="copyChatgpt" type="button">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="8" y="8" width="11" height="11" rx="2" /><path d="M16 8V6a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h2" /></svg>
+                Copy + open ChatGPT
+              </button>
+              <button class="button" id="download" type="button">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12m0 0 4-4m-4 4-4-4M5 20h14" /></svg>
+                Download
+              </button>
+              <button class="button" id="save" type="button">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 3h12l2 2v16H5z" /><path d="M8 3v6h8V3M8 21v-7h8v7" /></svg>
+                Save scope
+              </button>
+            </div>
+            <div class="status" id="status" role="status" aria-live="polite"></div>
+            <p class="privacy-note" id="privacyNote">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><rect x="5" y="10" width="14" height="10" rx="2" /><path d="M8 10V7a4 4 0 0 1 8 0v3" /></svg>
+              Files are read by this localhost app only. Nothing is sent until you paste it into ChatGPT.
+            </p>
+          </footer>
+        </section>
+      </main>
+    </div>
+
+    <script>
+      'use strict';
+
+      const ICONS = {
+        chevron: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="m9 18 6-6-6-6" /></svg>',
+        folder: '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 6.5h7l2 2h9v10H3z" /></svg>',
+        file: '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 3h8l4 4v14H6z" /><path d="M14 3v5h4" /></svg>',
+        spinner: '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M21 12a9 9 0 1 1-6.2-8.6" /></svg>'
+      };
+      const TIER_LABELS = { 4: 'RW', 3: 'RO', 2: 'SIG', 1: 'LIST', 0: 'OFF' };
+      const TIER_TITLES = {
+        4: 'Full content, read-write scope',
+        3: 'Full content, read-only scope',
+        2: 'Signatures only',
+        1: 'List the file path without content',
+        0: 'Exclude'
+      };
+      const ACCESS_TOKEN = document.querySelector('meta[name="consurg-token"]').content;
+      const elements = Object.fromEntries([
+        'chooseFolder', 'rootDescription', 'fileCount', 'search', 'clearSearch', 'bulkLabel',
+        'selectFiltered', 'clearFiltered', 'treeLoading', 'fileTree', 'emptyState', 'emptyTitle',
+        'emptyCopy', 'treeError', 'treeErrorCopy', 'scopeName', 'format', 'task', 'prompt',
+        'totals', 'composeState', 'copyChatgpt', 'download', 'save', 'status'
+      ].map((id) => [id, document.getElementById(id)]));
+
+      let files = [];
+      let tiers = {};
+      let previousTiers = {};
+      let rootName = '';
+      let expandedFolders = new Set();
+      let composeTimer = null;
+      let composeController = null;
+      let composeSequence = 0;
+      let latestCompose = Promise.resolve();
+
+      function normalizeTier(tier) {
+        return [4, 3, 2, 1].includes(Number(tier)) ? Number(tier) : 0;
+      }
+
+      async function fetchJson(url, options = {}) {
+        const requestOptions = {
+          ...options,
+          headers: { ...(options.headers || {}), 'X-Consurg-Token': ACCESS_TOKEN }
+        };
+        const response = await fetch(url, requestOptions);
+        let payload = {};
+        try { payload = await response.json(); } catch { /* handled below */ }
+        if (!response.ok) {
+          const error = new Error(payload.error || `Request failed (${response.status})`);
+          error.status = response.status;
+          error.payload = payload;
+          throw error;
+        }
+        return payload;
+      }
+
+      function invalidateCompose() {
+        clearTimeout(composeTimer);
+        composeTimer = null;
+        composeSequence += 1;
+        if (composeController) composeController.abort();
+        composeController = null;
+        latestCompose = Promise.resolve(false);
+        elements.prompt.removeAttribute('aria-busy');
+      }
+
+      function applyFilesPayload(payload) {
+        invalidateCompose();
+        elements.prompt.value = '';
+        elements.composeState.textContent = 'Updating…';
+        files = Array.isArray(payload.files) ? payload.files : [];
+        tiers = {};
+        previousTiers = {};
+        files.forEach((file) => {
+          const tier = normalizeTier(file.tier);
+          tiers[file.path] = tier;
+          if (tier > 0) previousTiers[file.path] = tier;
+        });
+        rootName = payload.root_name || 'selected folder';
+        elements.scopeName.value = payload.scope_name || '';
+        expandedFolders = new Set();
+        const firstSegments = new Set(
+          files.filter((file) => file.path.includes('/')).map((file) => file.path.split('/')[0])
+        );
+        if (firstSegments.size <= 8) firstSegments.forEach((part) => expandedFolders.add(part));
+        elements.rootDescription.textContent = rootName;
+        elements.fileCount.textContent = `${files.length.toLocaleString()} ${files.length === 1 ? 'file' : 'files'}`;
+        elements.treeLoading.hidden = true;
+        elements.treeError.hidden = true;
+        renderTree();
+        updateTotals();
+        scheduleCompose();
+      }
+
+      async function loadFiles() {
+        showTreeLoading();
+        try {
+          applyFilesPayload(await fetchJson('/api/files'));
+        } catch (error) {
+          showTreeError(error.message);
+          setStatus(error.message, 'error');
+        }
+      }
+
+      function showTreeLoading() {
+        elements.treeLoading.hidden = false;
+        elements.fileTree.hidden = true;
+        elements.emptyState.hidden = true;
+        elements.treeError.hidden = true;
+      }
+
+      function showTreeError(message) {
+        elements.treeLoading.hidden = true;
+        elements.fileTree.hidden = true;
+        elements.emptyState.hidden = true;
+        elements.treeError.hidden = false;
+        elements.treeErrorCopy.textContent = message || 'Try choosing the folder again.';
+      }
+
+      function filteredFiles() {
+        const query = elements.search.value.trim().toLocaleLowerCase();
+        if (!query) return files;
+        return files.filter((file) => file.path.toLocaleLowerCase().includes(query));
+      }
+
+      function createTree(items) {
+        const root = { name: '', path: '', directories: new Map(), files: [], descendants: [] };
+        items.forEach((file) => {
+          const parts = file.path.split('/');
+          let node = root;
+          node.descendants.push(file);
+          parts.slice(0, -1).forEach((part) => {
+            if (!node.directories.has(part)) {
+              const path = node.path ? `${node.path}/${part}` : part;
+              node.directories.set(part, { name: part, path, directories: new Map(), files: [], descendants: [] });
+            }
+            node = node.directories.get(part);
+            node.descendants.push(file);
+          });
+          node.files.push(file);
+        });
+        return root;
+      }
+
+      function focusedTreeControl() {
+        const active = document.activeElement;
+        return active instanceof HTMLElement && elements.fileTree.contains(active) ? active.dataset.focusKey || null : null;
+      }
+
+      function restoreTreeFocus(focusKey) {
+        if (!focusKey) return;
+        const control = elements.fileTree.querySelector(`[data-focus-key="${CSS.escape(focusKey)}"]`);
+        if (control instanceof HTMLElement) control.focus({ preventScroll: true });
+      }
+
+      function renderTree(focusKey = focusedTreeControl()) {
+        const shown = filteredFiles();
+        const query = elements.search.value.trim();
+        elements.clearSearch.hidden = !query;
+        elements.bulkLabel.textContent = query ? `${shown.length.toLocaleString()} matching files` : 'Select files to include as context';
+        elements.fileTree.replaceChildren();
+
+        if (!shown.length) {
+          elements.fileTree.hidden = true;
+          elements.emptyState.hidden = false;
+          elements.emptyTitle.textContent = files.length ? 'No matching files' : 'No files found';
+          elements.emptyCopy.textContent = files.length ? 'Try a different file or folder name.' : 'Choose a folder that contains readable project files.';
+          updateTotals();
+          return;
+        }
+
+        elements.emptyState.hidden = true;
+        elements.fileTree.hidden = false;
+        const tree = createTree(shown);
+        appendTreeChildren(elements.fileTree, tree, Boolean(query));
+        updateTotals();
+        restoreTreeFocus(focusKey);
+      }
+
+      function appendTreeChildren(container, node, forceOpen) {
+        [...node.directories.values()]
+          .sort((a, b) => a.name.localeCompare(b.name))
+          .forEach((directory) => container.appendChild(createDirectoryItem(directory, forceOpen)));
+        node.files
+          .sort((a, b) => a.path.localeCompare(b.path))
+          .forEach((file) => container.appendChild(createFileItem(file)));
+      }
+
+      function selectable(items) {
+        return items.filter((file) => !file.denied);
+      }
+
+      function selectionState(items) {
+        const allowed = selectable(items);
+        const selected = allowed.filter((file) => tiers[file.path] >= 1).length;
+        return { allowed, selected, checked: allowed.length > 0 && selected === allowed.length, mixed: selected > 0 && selected < allowed.length };
+      }
+
+      function createDirectoryItem(directory, forceOpen) {
+        const item = document.createElement('li');
+        item.className = 'tree-item';
+        const isOpen = forceOpen || expandedFolders.has(directory.path);
+
+        const row = document.createElement('div');
+        row.className = 'tree-row folder-row';
+
+        const disclosure = document.createElement('button');
+        disclosure.type = 'button';
+        disclosure.className = 'icon-button disclosure';
+        disclosure.dataset.focusKey = `directory:${directory.path}:disclosure`;
+        disclosure.setAttribute('aria-label', `${isOpen ? 'Collapse' : 'Expand'} ${directory.name}`);
+        disclosure.setAttribute('aria-expanded', String(isOpen));
+        disclosure.innerHTML = ICONS.chevron;
+
+        const state = selectionState(directory.descendants);
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.className = 'selection-box';
+        checkbox.dataset.focusKey = `directory:${directory.path}:checkbox`;
+        checkbox.checked = state.checked;
+        checkbox.indeterminate = state.mixed;
+        checkbox.disabled = state.allowed.length === 0;
+        checkbox.setAttribute('aria-label', `${state.checked ? 'Exclude' : 'Include'} all files in ${directory.path}`);
+
+        const icon = document.createElement('span');
+        icon.className = 'tree-icon';
+        icon.innerHTML = ICONS.folder;
+
+        const name = document.createElement('span');
+        name.className = 'tree-name';
+        name.textContent = directory.name;
+        name.title = directory.path;
+
+        const count = document.createElement('span');
+        count.className = 'token-count';
+        count.textContent = `${directory.descendants.length} ${directory.descendants.length === 1 ? 'file' : 'files'}`;
+
+        row.append(disclosure, checkbox, icon, name, count);
+        const group = document.createElement('ul');
+        group.className = 'tree-group';
+        group.hidden = !isOpen;
+        appendTreeChildren(group, directory, forceOpen);
+
+        disclosure.addEventListener('click', () => {
+          const opening = group.hidden;
+          group.hidden = !opening;
+          disclosure.setAttribute('aria-expanded', String(opening));
+          disclosure.setAttribute('aria-label', `${opening ? 'Collapse' : 'Expand'} ${directory.name}`);
+          if (opening) expandedFolders.add(directory.path);
+          else expandedFolders.delete(directory.path);
+        });
+        checkbox.addEventListener('change', () => setFilesTier(state.allowed, checkbox.checked ? 3 : 0));
+
+        item.append(row, group);
+        return item;
+      }
+
+      function createFileItem(file) {
+        const item = document.createElement('li');
+        item.className = 'tree-item';
+
+        const row = document.createElement('div');
+        const selected = tiers[file.path] >= 1;
+        row.className = `tree-row${selected ? ' is-selected' : ''}${file.denied ? ' is-denied' : ''}`;
+
+        const placeholder = document.createElement('span');
+        placeholder.className = 'disclosure-placeholder';
+
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.className = 'selection-box';
+        checkbox.dataset.focusKey = `file:${file.path}:checkbox`;
+        checkbox.checked = selected;
+        checkbox.disabled = file.denied;
+        checkbox.setAttribute('aria-label', `${selected ? 'Exclude' : 'Include'} ${file.path}`);
+
+        const icon = document.createElement('span');
+        icon.className = 'tree-icon';
+        icon.innerHTML = ICONS.file;
+
+        const name = document.createElement('span');
+        name.className = 'tree-name';
+        name.textContent = file.path.split('/').pop();
+        name.title = file.path;
+
+        const tokens = document.createElement('span');
+        tokens.className = 'token-count';
+        tokens.textContent = `~${Number(file.tokens || 0).toLocaleString()} tok`;
+
+        if (file.denied) {
+          const policy = document.createElement('span');
+          policy.className = 'policy-label';
+          policy.textContent = 'policy';
+          policy.title = 'Excluded by the local never_include policy';
+          row.append(placeholder, checkbox, icon, name, policy, tokens);
+        } else {
+          row.append(placeholder, checkbox, icon, name, createTierControl(file), tokens);
+        }
+
+        checkbox.addEventListener('change', () => {
+          const restored = normalizeTier(previousTiers[file.path]) || 3;
+          setFilesTier([file], checkbox.checked ? restored : 0);
+        });
+        item.appendChild(row);
+        return item;
+      }
+
+      function createTierControl(file) {
+        const control = document.createElement('div');
+        control.className = 'tier-control';
+        control.setAttribute('role', 'group');
+        control.setAttribute('aria-label', `Context level for ${file.path}`);
+        [4, 3, 2, 1, 0].forEach((tier) => {
+          const button = document.createElement('button');
+          button.type = 'button';
+          button.className = 'tier-button';
+          button.dataset.tier = String(tier);
+          button.dataset.focusKey = `file:${file.path}:tier:${tier}`;
+          button.textContent = TIER_LABELS[tier];
+          button.title = TIER_TITLES[tier];
+          button.setAttribute('aria-pressed', String(tiers[file.path] === tier));
+          button.addEventListener('click', () => setFilesTier([file], tier));
+          control.appendChild(button);
+        });
+        return control;
+      }
+
+      function setFilesTier(targets, tier) {
+        const focusKey = focusedTreeControl();
+        targets.forEach((file) => {
+          if (file.denied && tier !== 0) return;
+          tiers[file.path] = tier;
+          if (tier >= 1) previousTiers[file.path] = tier;
+        });
+        renderTree(focusKey);
+        scheduleCompose();
+      }
+
+      function selectedTiers() {
+        return Object.fromEntries(Object.entries(tiers).filter(([, tier]) => tier >= 1));
+      }
+
+      function updateTotals(serverTokens) {
+        const selected = selectedTiers();
+        const count = Object.keys(selected).length;
+        let estimate = 0;
+        files.forEach((file) => {
+          const tier = selected[file.path];
+          if (tier === 4 || tier === 3) estimate += Number(file.tokens || 0);
+          else if (tier === 2) estimate += Math.min(Number(file.tokens || 0), 150);
+        });
+        const tokens = serverTokens == null ? estimate : serverTokens;
+        elements.totals.textContent = `${count.toLocaleString()} ${count === 1 ? 'file' : 'files'} · ~${Number(tokens || 0).toLocaleString()} tokens`;
+      }
+
+      function scheduleCompose() {
+        invalidateCompose();
+        clearTimeout(composeTimer);
+        elements.composeState.textContent = 'Updating…';
+        composeTimer = setTimeout(() => { latestCompose = refreshPrompt(); }, 220);
+      }
+
+      async function refreshPrompt() {
+        const sequence = ++composeSequence;
+        if (composeController) composeController.abort();
+        composeController = new AbortController();
+        elements.prompt.setAttribute('aria-busy', 'true');
+        elements.composeState.textContent = 'Updating…';
+        try {
+          const payload = await fetchJson('/api/compose', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              tiers: selectedTiers(),
+              format: elements.format.value,
+              task: elements.task.value,
+              scope_name: elements.scopeName.value
+            }),
+            signal: composeController.signal
+          });
+          if (sequence !== composeSequence) return false;
+          elements.prompt.value = payload.prompt || '';
+          updateTotals(payload.tokens);
+          elements.composeState.textContent = 'Ready';
+          if (payload.skipped && payload.skipped.length) {
+            const details = payload.skipped.map((item) => `${item.path} (${item.reason})`).join(', ');
+            setStatus(`Omitted: ${details}`, 'warning', 'compose');
+          } else if (elements.status.dataset.source === 'compose') {
+            setStatus('');
+          }
+          return true;
+        } catch (error) {
+          if (error.name === 'AbortError') return false;
+          elements.composeState.textContent = 'Could not update';
+          setStatus(error.message, 'error', 'compose');
+          return false;
+        } finally {
+          if (sequence === composeSequence) elements.prompt.setAttribute('aria-busy', 'false');
+        }
+      }
+
+      async function ensureComposed() {
+        clearTimeout(composeTimer);
+        latestCompose = refreshPrompt();
+        const ready = await latestCompose;
+        if (!ready) throw new Error('Context changed while composing. Try again');
+      }
+
+      async function writeClipboard(text) {
+        if (navigator.clipboard && window.isSecureContext) {
+          await navigator.clipboard.writeText(text);
+          return;
+        }
+        elements.prompt.focus();
+        elements.prompt.select();
+        if (!document.execCommand('copy')) throw new Error('Clipboard permission was denied');
+      }
+
+      async function copyAndOpenChatGpt() {
+        try { window.open('https://chatgpt.com/', '_blank', 'noopener,noreferrer'); } catch { /* clipboard still works */ }
+        elements.copyChatgpt.disabled = true;
+        try {
+          await ensureComposed();
+          await writeClipboard(elements.prompt.value);
+          setStatus('Copied. A ChatGPT tab was requested; if it did not open, open ChatGPT and paste into the composer.', 'success');
+        } catch (error) {
+          setStatus(`${error.message}. Select the preview and copy it manually.`, 'error');
+        } finally {
+          elements.copyChatgpt.disabled = false;
+        }
+      }
+
+      async function openFolder() {
+        const original = elements.chooseFolder.innerHTML;
+        elements.chooseFolder.disabled = true;
+        elements.chooseFolder.classList.add('is-busy');
+        elements.chooseFolder.innerHTML = `${ICONS.spinner}<span class="button-label-optional">Waiting for folder…</span>`;
+        setStatus('Choose a local folder in the system dialog.');
+        try {
+          const payload = await fetchJson('/api/open-folder', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: '{}'
+          });
+          if (payload.cancelled) {
+            setStatus('Folder selection cancelled.');
+            return;
+          }
+          elements.search.value = '';
+          applyFilesPayload(payload);
+          setStatus(`Opened ${payload.root_name || 'folder'}.`, 'success');
+        } catch (error) {
+          setStatus(error.message, 'error');
+        } finally {
+          elements.chooseFolder.disabled = false;
+          elements.chooseFolder.classList.remove('is-busy');
+          elements.chooseFolder.innerHTML = original;
+        }
+      }
+
+      async function downloadPrompt() {
+        elements.download.disabled = true;
+        try {
+          await ensureComposed();
+          const blob = new Blob([elements.prompt.value], { type: 'text/plain;charset=utf-8' });
+          const url = URL.createObjectURL(blob);
+          const link = document.createElement('a');
+          link.href = url;
+          link.download = `${rootName || 'consurg'}-context.txt`;
+          document.body.appendChild(link);
+          link.click();
+          link.remove();
+          URL.revokeObjectURL(url);
+          setStatus('Context downloaded.', 'success');
+        } catch (error) {
+          setStatus(error.message, 'error');
+        } finally {
+          elements.download.disabled = false;
+        }
+      }
+
+      async function saveScope() {
+        elements.save.disabled = true;
+        const requestSave = (confirmWildcardExpansion = false) => fetchJson('/api/save-scope', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            tiers: selectedTiers(),
+            scope_name: elements.scopeName.value,
+            ...(confirmWildcardExpansion ? { confirm_wildcard_expansion: true } : {})
+          })
+        });
+        try {
+          let payload;
+          try {
+            payload = await requestSave();
+          } catch (error) {
+            if (error.status !== 409 || !error.payload?.requires_wildcard_confirmation) throw error;
+            const confirmed = window.confirm('Saving will expand wildcard scope entries into explicit file paths. Continue?');
+            if (!confirmed) {
+              setStatus('Scope save cancelled; wildcard entries were not expanded.', 'warning');
+              return;
+            }
+            payload = await requestSave(true);
+          }
+          setStatus(`Scope saved to ${payload.saved || '.consurg.yaml'}.`, 'success');
+        } catch (error) {
+          setStatus(error.message, 'error');
+        } finally {
+          elements.save.disabled = false;
+        }
+      }
+
+      function setStatus(message, tone = 'neutral', source = '') {
+        elements.status.textContent = message;
+        elements.status.dataset.tone = tone;
+        elements.status.dataset.source = source;
+      }
+
+      elements.chooseFolder.addEventListener('click', openFolder);
+      elements.search.addEventListener('input', renderTree);
+      elements.search.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape' && elements.search.value) {
+          elements.search.value = '';
+          renderTree();
+        }
+      });
+      elements.clearSearch.addEventListener('click', () => {
+        elements.search.value = '';
+        elements.search.focus();
+        renderTree();
+      });
+      elements.selectFiltered.addEventListener('click', () => setFilesTier(selectable(filteredFiles()), 3));
+      elements.clearFiltered.addEventListener('click', () => setFilesTier(filteredFiles(), 0));
+      elements.format.addEventListener('change', scheduleCompose);
+      elements.task.addEventListener('input', scheduleCompose);
+      elements.scopeName.addEventListener('input', scheduleCompose);
+      elements.copyChatgpt.addEventListener('click', copyAndOpenChatGpt);
+      elements.download.addEventListener('click', downloadPrompt);
+      elements.save.addEventListener('click', saveScope);
+      document.addEventListener('keydown', (event) => {
+        if ((event.ctrlKey || event.metaKey) && event.key === 'Enter') {
+          event.preventDefault();
+          copyAndOpenChatGpt();
+        }
+      });
+
+      loadFiles();
+    </script>
+  </body>
+</html>

--- a/consurg/file_context_ui.py
+++ b/consurg/file_context_ui.py
@@ -1,19 +1,28 @@
 from __future__ import annotations
 
 import json
+import os
+import secrets
 import subprocess
 import threading
+import tempfile
 import webbrowser
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse
 
 import yaml
 
 from consurg.enforce import resolve_tier
-from consurg.render import compose_from_tiers, estimate_file_tokens
+from consurg.render import (
+    HARD_MAX_FILE_BYTES,
+    HARD_MAX_TOTAL_BYTES,
+    compose_from_tiers,
+    estimate_file_tokens,
+    safe_read_context_file,
+)
 from consurg.scope import load_scope, pattern_matches
 
 
@@ -37,6 +46,7 @@ IGNORED_DIR_NAMES = {
     ".git",
     "__pycache__",
     ".pytest_cache",
+    ".llm-router",
     "node_modules",
     ".next",
     "dist",
@@ -53,6 +63,7 @@ _DEFAULT_DENY_PATTERNS = [
     ".venv",
     "dist",
     ".pytest_cache",
+    ".llm-router",
     ".next",
     "*.pyc",
 ]
@@ -65,27 +76,42 @@ def load_file_context_ui_config(cwd: Path) -> FileContextUIConfig:
     hide_excluded = False
 
     cfg_path = cwd / SCOPE_FILE
+    data: dict[str, Any] = {}
     if cfg_path.exists():
-        with cfg_path.open(encoding="utf-8") as f:
-            data = yaml.safe_load(f) or {}
-        ui_cfg = data.get("file_context_ui", {})
-        if isinstance(ui_cfg, dict):
-            cfg_never_include = ui_cfg.get("never_include")
-            if isinstance(cfg_never_include, list):
-                normalized = [_coerce_pattern(v) for v in cfg_never_include]
-                if normalized:
-                    config = normalized
+        try:
+            with cfg_path.open(encoding="utf-8") as f:
+                loaded = yaml.safe_load(f) or {}
+            if isinstance(loaded, dict):
+                data = loaded
+        except (OSError, yaml.YAMLError):
+            data = {}
 
-            cfg_max_file_bytes = ui_cfg.get("max_file_bytes")
-            if isinstance(cfg_max_file_bytes, int) and cfg_max_file_bytes > 0:
-                max_file_bytes = cfg_max_file_bytes
+    ui_cfg = data.get("file_context_ui", {})
+    if isinstance(ui_cfg, dict):
+        cfg_never_include = ui_cfg.get("never_include")
+        if isinstance(cfg_never_include, list):
+            normalized = [_coerce_pattern(value) for value in cfg_never_include]
+            if normalized:
+                config = normalized
 
-            cfg_max_total_bytes = ui_cfg.get("max_total_bytes")
-            if isinstance(cfg_max_total_bytes, int) and cfg_max_total_bytes > 0:
-                max_total_bytes = cfg_max_total_bytes
+        cfg_max_file_bytes = ui_cfg.get("max_file_bytes")
+        if (
+            isinstance(cfg_max_file_bytes, int)
+            and not isinstance(cfg_max_file_bytes, bool)
+            and cfg_max_file_bytes > 0
+        ):
+            max_file_bytes = min(cfg_max_file_bytes, HARD_MAX_FILE_BYTES)
 
-            if isinstance(ui_cfg.get("hide_excluded"), bool):
-                hide_excluded = ui_cfg.get("hide_excluded")
+        cfg_max_total_bytes = ui_cfg.get("max_total_bytes")
+        if (
+            isinstance(cfg_max_total_bytes, int)
+            and not isinstance(cfg_max_total_bytes, bool)
+            and cfg_max_total_bytes > 0
+        ):
+            max_total_bytes = min(cfg_max_total_bytes, HARD_MAX_TOTAL_BYTES)
+
+        if isinstance(ui_cfg.get("hide_excluded"), bool):
+            hide_excluded = ui_cfg["hide_excluded"]
 
     return FileContextUIConfig(
         never_include=config,
@@ -95,36 +121,66 @@ def load_file_context_ui_config(cwd: Path) -> FileContextUIConfig:
     )
 
 
-def list_candidate_files(cwd: Path, config: FileContextUIConfig | None = None) -> list[str]:
+def list_candidate_files(
+    cwd: Path, config: FileContextUIConfig | None = None
+) -> list[str]:
     repo_files: list[str] = []
     try:
         result = subprocess.run(
-            ["git", "ls-files"],
+            [
+                "git",
+                "-c",
+                "core.quotepath=false",
+                "ls-files",
+                "-z",
+                "--cached",
+                "--others",
+                "--exclude-standard",
+            ],
             capture_output=True,
-            text=True,
             cwd=str(cwd),
+            timeout=10,
+            check=False,
         )
         if result.returncode == 0:
-            repo_files = [
-                str(Path(line.strip()).as_posix())
-                for line in result.stdout.strip().splitlines()
-                if line.strip()
-            ]
-    except FileNotFoundError:
+            stdout = result.stdout
+            entries = (
+                stdout.split(b"\0")
+                if isinstance(stdout, bytes)
+                else stdout.split("\0")
+            )
+            for entry in entries:
+                if isinstance(entry, bytes):
+                    line = entry.decode("utf-8", errors="surrogateescape")
+                else:
+                    line = entry
+                if not line:
+                    continue
+                normalized = Path(line).as_posix()
+                if not normalized:
+                    continue
+                candidate = cwd / normalized
+                if candidate.is_file() and not any(
+                    part in IGNORED_DIR_NAMES for part in Path(normalized).parts
+                ):
+                    repo_files.append(normalized)
+    except (FileNotFoundError, subprocess.TimeoutExpired):
         repo_files = []
 
     if repo_files:
         return sorted(set(repo_files))
 
-    # Fallback to filesystem walk when git is unavailable.
+    # Fallback to a pruned filesystem walk when git is unavailable.
     repo_files = []
-    for path in cwd.rglob("*"):
-        if not path.is_file():
-            continue
-        if any(part in IGNORED_DIR_NAMES for part in path.parts):
-            continue
-        relative = path.relative_to(cwd).as_posix()
-        repo_files.append(relative)
+    for root, dir_names, file_names in os.walk(cwd, topdown=True, followlinks=False):
+        dir_names[:] = sorted(
+            name for name in dir_names if name not in IGNORED_DIR_NAMES
+        )
+        root_path = Path(root)
+        for file_name in sorted(file_names):
+            path = root_path / file_name
+            if path.is_file():
+                repo_files.append(path.relative_to(cwd).as_posix())
 
     return sorted(set(repo_files))
 
@@ -140,53 +196,95 @@ def is_denied(path: str, deny_patterns: list[str]) -> bool:
     return False
 
 
-def initial_tiers(cwd: Path, candidates: list[str]) -> tuple[dict[str, int], str]:
+def initial_tiers(
+    cwd: Path, candidates: list[str], config: FileContextUIConfig | None = None
+) -> tuple[dict[str, int], str]:
     """Resolve the starting tier for each candidate from .consurg.yaml.
 
     Returns ({path: tier}, scope_name). Files without a scope match get tier 0.
     """
-    scope = None
     try:
         scope = load_scope(cwd / SCOPE_FILE)
     except Exception:
         scope = None
-
     if scope is None:
         return ({p: 0 for p in candidates}, "")
 
     tiers = {}
     for rel in candidates:
         tier, _ = resolve_tier(rel, scope)
-        tiers[rel] = tier
+        tiers[rel] = 0 if config and is_denied(rel, config.never_include) else tier
     return (tiers, scope.scope_name)
 
+class ScopeExpansionConfirmationRequired(Exception):
+    """Raised before turning selected wildcard matches into explicit paths."""
 
-def save_scope_tiers(cwd: Path, tiers: dict[str, int], scope_name: str = "") -> Path:
-    """Write explicit per-file tier lists into .consurg.yaml, preserving other keys."""
+
+def save_scope_tiers(
+    cwd: Path,
+    tiers: dict[str, int],
+    scope_name: str = "",
+    *,
+    manage_visible: bool = False,
+    candidates: list[str] | None = None,
+    previous_tiers: dict[str, int] | None = None,
+    confirm_wildcard_expansion: bool = False,
+) -> Path:
+    """Write explicit per-file tiers into .consurg.yaml, preserving other keys."""
     scope_path = cwd / SCOPE_FILE
-    data: dict = {}
+    data: dict[str, Any] = {}
     if scope_path.exists():
         with scope_path.open(encoding="utf-8") as f:
-            data = yaml.safe_load(f) or {}
+            loaded = yaml.safe_load(f) or {}
+        if isinstance(loaded, dict):
+            data = loaded
 
     data.setdefault("version", 1)
     data["scope"] = scope_name or data.get("scope") or cwd.name
     data.setdefault("active", True)
     data.setdefault("reason", "")
 
-    data["working_set"] = sorted(p for p, t in tiers.items() if t == 4)
-    data["reference"] = sorted(p for p, t in tiers.items() if t == 3)
-    data["signatures"] = sorted(p for p, t in tiers.items() if t == 2)
-    # Tier 1 (existence) is not managed by the picker; preserve what's there.
-    data.setdefault("visible", [])
+    if candidates is None or previous_tiers is None:
+        data["working_set"] = sorted(path for path, tier in tiers.items() if tier == 4)
+        data["reference"] = sorted(path for path, tier in tiers.items() if tier == 3)
+        data["signatures"] = sorted(path for path, tier in tiers.items() if tier == 2)
+        if manage_visible:
+            data["visible"] = sorted(path for path, tier in tiers.items() if tier == 1)
+        else:
+            data.setdefault("visible", [])
+    else:
+        _update_scope_entries(
+            data,
+            tiers,
+            candidates,
+            previous_tiers,
+            manage_visible=manage_visible,
+            confirm_wildcard_expansion=confirm_wildcard_expansion,
+        )
     data.setdefault("dynamic_deps", [])
 
-    with scope_path.open("w", encoding="utf-8") as f:
-        yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+    temp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=cwd,
+            prefix=".consurg-",
+            suffix=".tmp",
+            delete=False,
+        ) as temp_file:
+            yaml.dump(data, temp_file, default_flow_style=False, sort_keys=False)
+            temp_path = Path(temp_file.name)
+        os.replace(temp_path, scope_path)
+    finally:
+        if temp_path is not None and temp_path.exists():
+            temp_path.unlink()
     return scope_path
 
 
-def compose_prompt(paths: list[str], cwd: Path, config: FileContextUIConfig, format: str = "markdown") -> str:
+def compose_prompt(
+    paths: list[str], cwd: Path, config: FileContextUIConfig, format: str = "markdown"
+) -> str:
     """Legacy flat-list compose: every path is rendered as full content."""
     safe_paths = []
     for path in paths:
@@ -211,19 +309,25 @@ def compose_prompt(paths: list[str], cwd: Path, config: FileContextUIConfig, for
             continue
 
         body, size = _render_file_block(rel_path, cwd, format, config)
-        if total_bytes + size > config.max_total_bytes:
+        if total_bytes + size > min(config.max_total_bytes, HARD_MAX_TOTAL_BYTES):
             if not used_marker:
-                blocks.append(TRUNCATION_MARKER)
-                used_marker = True
+                marker = (
+                    "<truncated>total size limit reached</truncated>\n"
+                    if format == "xml"
+                    else TRUNCATION_MARKER
+                )
+                blocks.append(marker)
             truncated = True
             break
         blocks.append(body)
         total_bytes += size
 
+    rendered = "".join(blocks)
+    if format == "xml":
+        return f"<context>\n{rendered}</context>"
     if truncated:
-        return "".join(blocks)
-
-    return "".join(blocks).rstrip()
+        return rendered
+    return rendered.rstrip()
 
 
 def start_ui_server(
@@ -232,7 +336,7 @@ def start_ui_server(
     preselected: list[str] | None = None,
 ):
     candidates = list_candidate_files(cwd, config)
-    tiers, scope_name = initial_tiers(cwd, candidates)
+    tiers, scope_name = initial_tiers(cwd, candidates, config)
 
     # Preselected files (CLI args) default to read-write if not already scoped.
     for raw in _normalize_preselected(preselected or [], cwd):
@@ -240,13 +344,22 @@ def start_ui_server(
         if rel in tiers and tiers[rel] == 0:
             tiers[rel] = 4
 
-    handler = _make_request_handler(cwd, config, candidates, tiers, scope_name)
+    access_token = secrets.token_urlsafe(32)
+    handler = _make_request_handler(
+        cwd,
+        config,
+        candidates,
+        tiers,
+        scope_name,
+        access_token=access_token,
+    )
 
     # Threading matters: browsers hold open preconnect sockets that would
     # deadlock a single-threaded server's accept loop.
     server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    server.daemon_threads = True
     port = server.server_address[1]
-    server_url = f"http://127.0.0.1:{port}/"
+    server_url = f"http://127.0.0.1:{port}/?token={access_token}"
 
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
@@ -271,55 +384,131 @@ def _make_request_handler(
     candidates: list[str],
     tiers: dict[str, int],
     scope_name: str,
+    *,
+    access_token: str | None = None,
 ):
+    server_token = access_token or secrets.token_urlsafe(32)
+    state: dict[str, Any] = {
+        "cwd": cwd,
+        "config": config,
+        "candidates": candidates,
+        "tiers": {
+            path: 0 if is_denied(path, config.never_include) else tiers.get(path, 0)
+            for path in candidates
+        },
+        "scope_name": scope_name,
+    }
+    state_lock = threading.RLock()
+    folder_picker_lock = threading.Lock()
+
     class FileContextHandler(BaseHTTPRequestHandler):
         def do_GET(self):  # noqa: N802
             parsed = urlparse(self.path)
             if parsed.path == "/":
+                supplied = parse_qs(parsed.query).get("token", [""])[0]
+                if not secrets.compare_digest(supplied, server_token):
+                    self.send_error(403, "Invalid picker token")
+                    return
                 self._send_html()
             elif parsed.path == "/api/files":
+                if not self._authorized_request():
+                    self.send_error(403, "Invalid picker token")
+                    return
                 self._send_json(self._files_payload())
             else:
                 self.send_error(404, "Not found")
 
         def do_POST(self):  # noqa: N802
+            if not self._same_origin_request():
+                self.send_error(403, "Cross-origin requests are not allowed")
+                return
+            if not self._authorized_request():
+                self.send_error(403, "Invalid picker token")
+                return
             parsed = urlparse(self.path)
             if parsed.path == "/api/compose":
                 self._handle_compose()
             elif parsed.path == "/api/save-scope":
                 self._handle_save_scope()
+            elif parsed.path == "/api/open-folder":
+                self._handle_open_folder()
             else:
                 self.send_error(404, "Not found")
 
+        def _authorized_request(self) -> bool:
+            supplied = self.headers.get("X-Consurg-Token", "")
+            return secrets.compare_digest(supplied, server_token)
+
+        def _same_origin_request(self) -> bool:
+            origin = self.headers.get("Origin")
+            host = self.headers.get("Host")
+            return not origin or (
+                host is not None and origin.rstrip("/") == f"http://{host}"
+            )
+
         def _read_body(self) -> dict | None:
-            length = int(self.headers.get("Content-Length", "0") or "0")
-            body = self.rfile.read(length).decode("utf-8")
             try:
-                return json.loads(body)
-            except json.JSONDecodeError:
+                length = int(self.headers.get("Content-Length", "0") or "0")
+            except ValueError:
+                self.send_error(400, "Invalid Content-Length")
+                return None
+            if length < 0 or length > 1_000_000:
+                self.send_error(413, "Request body is too large")
+                return None
+            try:
+                body = self.rfile.read(length).decode("utf-8")
+                payload = json.loads(body)
+            except (UnicodeDecodeError, json.JSONDecodeError):
                 self.send_error(400, "Invalid JSON")
                 return None
+            if not isinstance(payload, dict):
+                self.send_error(400, "JSON body must be an object")
+                return None
+            return payload
+
+        def _state_snapshot(
+            self,
+        ) -> tuple[Path, FileContextUIConfig, list[str], dict[str, int], str]:
+            with state_lock:
+                return (
+                    state["cwd"],
+                    state["config"],
+                    list(state["candidates"]),
+                    dict(state["tiers"]),
+                    state["scope_name"],
+                )
 
         def _handle_compose(self):
             payload = self._read_body()
             if payload is None:
                 return
-
-            requested = _sanitize_tiers(payload.get("tiers"), cwd)
+            current_cwd, current_config, current_candidates, _, current_scope = (
+                self._state_snapshot()
+            )
+            requested = _sanitize_tiers(
+                payload.get("tiers"),
+                current_cwd,
+                allowed_paths=set(current_candidates),
+                deny_patterns=current_config.never_include,
+            )
             fmt = payload.get("format", "markdown")
             if fmt not in {"markdown", "plain", "xml"}:
                 fmt = "markdown"
             task = payload.get("task", "")
             if not isinstance(task, str):
                 task = ""
+            requested_scope = payload.get("scope_name")
+            if not isinstance(requested_scope, str):
+                requested_scope = ""
+            requested_scope = requested_scope.strip()[:120]
 
             result = compose_from_tiers(
                 requested,
-                cwd,
-                limits=config,
+                current_cwd,
+                limits=current_config,
                 fmt=fmt,
                 task=task,
-                scope_name=payload.get("scope_name") or scope_name,
+                scope_name=requested_scope or current_scope,
             )
             self._send_json(
                 {
@@ -327,7 +516,8 @@ def _make_request_handler(
                     "tokens": result.token_estimate,
                     "included": len(result.included),
                     "skipped": [
-                        {"path": p, "reason": why} for p, why in result.skipped
+                        {"path": path, "reason": reason}
+                        for path, reason in result.skipped
                     ],
                 }
             )
@@ -336,56 +526,188 @@ def _make_request_handler(
             payload = self._read_body()
             if payload is None:
                 return
-            requested = _sanitize_tiers(payload.get("tiers"), cwd)
             name = payload.get("scope_name", "")
             if not isinstance(name, str):
                 name = ""
-            path = save_scope_tiers(cwd, requested, scope_name=name.strip())
+            name = name.strip()[:120]
+            confirmed = payload.get("confirm_wildcard_expansion") is True
+            with state_lock:
+                current_cwd = state["cwd"]
+                current_config = state["config"]
+                current_candidates = list(state["candidates"])
+                previous_tiers = dict(state["tiers"])
+                requested = _sanitize_tiers(
+                    payload.get("tiers"),
+                    current_cwd,
+                    allowed_paths=set(current_candidates),
+                    deny_patterns=current_config.never_include,
+                )
+                try:
+                    path = save_scope_tiers(
+                        current_cwd,
+                        requested,
+                        scope_name=name,
+                        manage_visible=True,
+                        candidates=current_candidates,
+                        previous_tiers=previous_tiers,
+                        confirm_wildcard_expansion=confirmed,
+                    )
+                except ScopeExpansionConfirmationRequired:
+                    self._send_json(
+                        {
+                            "error": "Saving these edits expands wildcard scope entries",
+                            "requires_wildcard_confirmation": True,
+                        },
+                        status=409,
+                    )
+                    return
+                except (OSError, yaml.YAMLError) as exc:
+                    self._send_json(
+                        {"error": f"Could not save the scope: {exc}"}, status=500
+                    )
+                    return
+                state["tiers"] = {
+                    path: requested.get(path, 0) for path in current_candidates
+                }
+                state["scope_name"] = name or state["scope_name"]
             self._send_json({"saved": str(path)})
 
+        def _handle_open_folder(self):
+            if self._read_body() is None:
+                return
+            if not folder_picker_lock.acquire(blocking=False):
+                self._send_json(
+                    {"error": "A folder picker is already open"}, status=409
+                )
+                return
+            try:
+                with state_lock:
+                    current_cwd = state["cwd"]
+                    try:
+                        selected = _choose_local_folder(current_cwd)
+                    except RuntimeError as exc:
+                        self._send_json({"error": str(exc)}, status=501)
+                        return
+                    if selected is None:
+                        self._send_json({"cancelled": True})
+                        return
+
+                    new_config = load_file_context_ui_config(selected)
+                    new_candidates = list_candidate_files(selected, new_config)
+                    new_tiers, new_scope_name = initial_tiers(
+                        selected, new_candidates, new_config
+                    )
+                    state.update(
+                        {
+                            "cwd": selected,
+                            "config": new_config,
+                            "candidates": new_candidates,
+                            "tiers": new_tiers,
+                            "scope_name": new_scope_name,
+                        }
+                    )
+                    response = self._files_payload()
+                response["changed"] = True
+                self._send_json(response)
+            except OSError as exc:
+                self._send_json(
+                    {"error": f"Could not open the folder: {exc}"}, status=500
+                )
+            finally:
+                folder_picker_lock.release()
+
         def _files_payload(self):
+            (
+                current_cwd,
+                current_config,
+                current_candidates,
+                current_tiers,
+                current_scope,
+            ) = self._state_snapshot()
             result = []
-            for path in candidates:
-                denied = is_denied(path, config.never_include)
-                if denied and config.hide_excluded and tiers.get(path, 0) == 0:
+            for path in current_candidates:
+                denied = is_denied(path, current_config.never_include)
+                if (
+                    denied
+                    and current_config.hide_excluded
+                    and current_tiers.get(path, 0) == 0
+                ):
+                    continue
+                safe = _safe_relative_path(path, current_cwd)
+                if safe is None:
                     continue
                 result.append(
                     {
                         "path": path,
-                        "tier": tiers.get(path, 0),
+                        "tier": current_tiers.get(path, 0),
                         "denied": denied,
-                        "tokens": estimate_file_tokens(cwd / path),
+                        "tokens": estimate_file_tokens(current_cwd / safe),
                     }
                 )
-            return {"files": result, "scope_name": scope_name}
+            return {
+                "files": result,
+                "scope_name": current_scope,
+                "root_name": current_cwd.name or str(current_cwd),
+            }
 
-        def _send_json(self, payload: dict):
+        def _security_headers(self):
+            self.send_header("Cache-Control", "no-store")
+            self.send_header("X-Content-Type-Options", "nosniff")
+            self.send_header("Referrer-Policy", "no-referrer")
+            self.send_header("Cross-Origin-Resource-Policy", "same-origin")
+            self.send_header(
+                "Content-Security-Policy",
+                "default-src 'self'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; "
+                "connect-src 'self'; img-src 'self' data:; base-uri 'none'; frame-ancestors 'none'",
+            )
+
+        def _send_json(self, payload: dict, status: int = 200):
             payload_text = json.dumps(payload)
-            self.send_response(200)
+            self.send_response(status)
             self.send_header("Content-Type", "application/json; charset=utf-8")
             self.send_header("Content-Length", str(len(payload_text.encode("utf-8"))))
+            self._security_headers()
             self.end_headers()
-            self.wfile.write(payload_text.encode("utf-8"))
+            try:
+                self.wfile.write(payload_text.encode("utf-8"))
+            except (BrokenPipeError, ConnectionResetError):
+                pass
 
         def _send_html(self):
-            page = _build_html()
+            page = _build_html(server_token)
             self.send_response(200)
             self.send_header("Content-Type", "text/html; charset=utf-8")
             self.send_header("Content-Length", str(len(page.encode("utf-8"))))
+            self._security_headers()
             self.end_headers()
-            self.wfile.write(page.encode("utf-8"))
+            try:
+                self.wfile.write(page.encode("utf-8"))
+            except (BrokenPipeError, ConnectionResetError):
+                pass
 
         def log_message(self, format, *args):  # noqa: A003
             return
 
+    FileContextHandler.access_token = server_token
     return FileContextHandler
 
 
-def _sanitize_tiers(raw: Any, cwd: Path) -> dict[str, int]:
-    """Validate a client-supplied {path: tier} map: safe paths, tiers 0-4."""
+def _sanitize_tiers(
+    raw: Any,
+    cwd: Path,
+    *,
+    allowed_paths: set[str] | None = None,
+    deny_patterns: list[str] | None = None,
+) -> dict[str, int]:
+    """Validate a client-supplied tier map against the current local root."""
     tiers: dict[str, int] = {}
     if not isinstance(raw, dict):
         return tiers
+    normalized_allowed = (
+        {_normalize_rel_path(path) for path in allowed_paths}
+        if allowed_paths is not None
+        else None
+    )
     for path, tier in raw.items():
         if not isinstance(path, str):
             continue
@@ -398,7 +720,12 @@ def _sanitize_tiers(raw: Any, cwd: Path) -> dict[str, int]:
         safe = _safe_relative_path(path, cwd)
         if safe is None:
             continue
-        tiers[safe.as_posix()] = tier_int
+        normalized = safe.as_posix()
+        if normalized_allowed is not None and normalized not in normalized_allowed:
+            continue
+        if deny_patterns and is_denied(normalized, deny_patterns):
+            continue
+        tiers[normalized] = tier_int
     return tiers
 
 
@@ -408,46 +735,113 @@ def _render_file_block(
     fmt: str,
     config: FileContextUIConfig,
 ) -> tuple[str, int]:
-    full_path = cwd / rel_path
-    if not full_path.exists():
-        content = _file_prompt_block(rel_path.as_posix(), MISSING_FILE_PLACEHOLDER, fmt)
-        return content, len(content.encode("utf-8"))
+    body, omission_reason = safe_read_context_file(
+        cwd / rel_path, cwd, config.max_file_bytes
+    )
+    placeholders = {
+        "file not found": MISSING_FILE_PLACEHOLDER,
+        "unreadable": MISSING_FILE_PLACEHOLDER,
+        "binary file": BINARY_FILE_PLACEHOLDER,
+        "exceeds max_file_bytes": LARGE_FILE_PLACEHOLDER,
+    }
+    rendered_body = placeholders.get(omission_reason, body or MISSING_FILE_PLACEHOLDER)
+    content = _file_prompt_block(rel_path.as_posix(), rendered_body, fmt)
+    return content, len(content.encode("utf-8"))
 
-    try:
-        size = full_path.stat().st_size
-    except OSError:
-        size = 0
 
-    if size > config.max_file_bytes:
-        content = _file_prompt_block(rel_path.as_posix(), LARGE_FILE_PLACEHOLDER, fmt)
-        return content, len(content.encode("utf-8"))
+def _has_wildcard(pattern: str) -> bool:
+    return any(marker in pattern for marker in ("*", "?", "["))
 
-    try:
-        with full_path.open("rb") as f:
-            chunk = f.read(8192)
-    except OSError:
-        content = _file_prompt_block(rel_path.as_posix(), MISSING_FILE_PLACEHOLDER, fmt)
-        return content, len(content.encode("utf-8"))
 
-    if b"\x00" in chunk:
-        content = _file_prompt_block(rel_path.as_posix(), BINARY_FILE_PLACEHOLDER, fmt)
-        return content, len(content.encode("utf-8"))
+def _update_scope_entries(
+    data: dict[str, Any],
+    tiers: dict[str, int],
+    candidates: list[str],
+    previous_tiers: dict[str, int],
+    *,
+    manage_visible: bool,
+    confirm_wildcard_expansion: bool,
+) -> None:
+    keys = ((4, "working_set"), (3, "reference"), (2, "signatures"), (1, "visible"))
+    changed = {
+        path
+        for path in candidates
+        if tiers.get(path, 0) != previous_tiers.get(path, 0)
+    }
+    if not changed:
+        return
 
-    try:
-        body = full_path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
-        body = full_path.read_bytes().decode("utf-8", errors="replace")
+    entries = {
+        key: [entry for entry in data.get(key, []) if isinstance(entry, str)]
+        for _, key in keys
+    }
+    relevant = [
+        entry
+        for values in entries.values()
+        for entry in values
+        if any(pattern_matches(path, entry) for path in changed)
+    ]
+    if not confirm_wildcard_expansion and any(_has_wildcard(entry) for entry in relevant):
+        raise ScopeExpansionConfirmationRequired
 
-    full_content = _file_prompt_block(rel_path.as_posix(), body, fmt)
-    return full_content, len(full_content.encode("utf-8"))
+    rewritten = set(changed)
+    while True:
+        matching_entries = [
+            entry
+            for values in entries.values()
+            for entry in values
+            if any(pattern_matches(path, entry) for path in rewritten)
+        ]
+        expanded = rewritten | {
+            path
+            for path in candidates
+            if any(pattern_matches(path, entry) for entry in matching_entries)
+        }
+        if expanded == rewritten:
+            break
+        rewritten = expanded
+
+    for tier, key in keys:
+        if tier == 1 and not manage_visible:
+            data.setdefault(key, [])
+            continue
+        retained = [
+            entry
+            for entry in entries[key]
+            if not any(pattern_matches(path, entry) for path in rewritten)
+        ]
+        retained.extend(
+            path for path in rewritten if tiers.get(path, 0) == tier
+        )
+        data[key] = sorted(set(retained))
 
 
 def _file_prompt_block(path: str, body: str, fmt: str) -> str:
+    if fmt == "xml":
+        return f'<file path="{_xml_escape(path)}">{_xml_escape(body)}</file>\n'
     if fmt == "plain":
         return f"{path}\n{'-' * max(3, len(path))}\n{body}\n\n"
 
     language = _infer_language(path)
     return f"## FILE: {path}\n```{language}\n{body}\n```\n\n"
+
+
+def _xml_escape(text: str) -> str:
+    valid = "".join(
+        char
+        for char in text
+        if ord(char) in (0x9, 0xA, 0xD)
+        or 0x20 <= ord(char) <= 0xD7FF
+        or 0xE000 <= ord(char) <= 0xFFFD
+        or 0x10000 <= ord(char) <= 0x10FFFF
+    )
+    return (
+        valid.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+        .replace("'", "&apos;")
+    )
 
 
 def _infer_language(path: str) -> str:
@@ -494,345 +888,46 @@ def _normalize_rel_path(path: str) -> str:
     return normalized
 
 
-def _build_html() -> str:
-    return """<!doctype html>
-<html>
-  <head>
-    <meta charset=\"utf-8\" />
-    <title>Consurg Scope Picker</title>
-    <style>
-      :root {
-        --bg: linear-gradient(120deg, #f5f7ff, #eef7ff);
-        --card: #ffffffdd;
-        --text: #0d1520;
-        --muted: #516173;
-        --accent: #2d6cdf;
-        --rw: #1d7a3d;
-        --ro: #2d6cdf;
-        --sig: #9a6b00;
-      }
-      body {
-        margin: 0;
-        font-family: ui-sans-serif, "Trebuchet MS", "Segoe UI", sans-serif;
-        color: var(--text);
-        background: var(--bg);
-      }
-      .wrap { max-width: 1200px; margin: 24px auto; padding: 16px; }
-      .panel {
-        background: var(--card);
-        border: 1px solid #cfd8ea;
-        border-radius: 14px;
-        box-shadow: 0 16px 40px #0f172a22;
-      }
-      .header {
-        padding: 14px 20px;
-        border-bottom: 1px solid #dce3f1;
-        display: flex;
-        align-items: baseline;
-        gap: 14px;
-      }
-      .header .title { font-weight: 700; font-size: 1.1rem; }
-      .header input { width: 200px; }
-      .row {
-        display: grid;
-        grid-template-columns: 1.2fr 1fr;
-        gap: 16px;
-        padding: 16px;
-      }
-      .files, .prompt {
-        border: 1px solid #dce3f1;
-        border-radius: 12px;
-        padding: 12px;
-      }
-      .files-list { max-height: 480px; overflow: auto; margin-top: 10px; }
-      .file-row {
-        display: flex;
-        gap: 8px;
-        align-items: center;
-        padding: 4px 2px;
-        border-bottom: 1px dashed #e8edf7;
-        font-size: 0.92rem;
-      }
-      .file-row .path { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-family: ui-monospace, Consolas, monospace; }
-      .file-row .tokens { color: var(--muted); font-size: 0.8rem; min-width: 60px; text-align: right; }
-      .tier-btns { display: flex; gap: 2px; }
-      .tier-btns button {
-        border: 1px solid #c7d2e4;
-        background: #f6f8fc;
-        color: var(--muted);
-        border-radius: 6px;
-        padding: 2px 7px;
-        font-size: 0.78rem;
-        cursor: pointer;
-      }
-      .tier-btns button.on-4 { background: var(--rw); color: white; border-color: transparent; }
-      .tier-btns button.on-3 { background: var(--ro); color: white; border-color: transparent; }
-      .tier-btns button.on-2 { background: var(--sig); color: white; border-color: transparent; }
-      .tier-btns button.on-0 { background: #64748b; color: white; border-color: transparent; }
-      .blocked { color: #b02c3e; font-size: 0.8rem; }
-      input[type='text'], select, textarea, button.action {
-        border: 1px solid #c7d2e4;
-        border-radius: 8px;
-        padding: 8px;
-      }
-      button.action {
-        background: var(--accent);
-        border-color: transparent;
-        color: white;
-        cursor: pointer;
-      }
-      button.action.secondary { background: #475569; }
-      textarea#prompt {
-        width: 100%;
-        height: 340px;
-        box-sizing: border-box;
-        resize: vertical;
-        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-        font-size: 0.85rem;
-      }
-      textarea#task {
-        width: 100%;
-        height: 54px;
-        box-sizing: border-box;
-        resize: vertical;
-        margin-top: 6px;
-      }
-      .actions { margin-top: 12px; display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
-      .muted { color: var(--muted); font-size: 0.92rem; }
-      .small { font-size: 0.85rem; }
-      .totals { font-weight: 700; }
-      .legend span { margin-right: 10px; }
-      .bulk { margin-top: 8px; display: flex; gap: 6px; align-items: center; font-size: 0.85rem; }
-    </style>
-  </head>
-  <body>
-    <div class="wrap">
-      <div class="panel">
-        <div class="header">
-          <span class="title">Consurg Scope Picker</span>
-          <span class="small muted">Scope name:</span>
-          <input type="text" id="scopeName" placeholder="scope name" />
-          <span class="small muted legend">
-            <span><b style="color:var(--rw)">RW</b> full read-write</span>
-            <span><b style="color:var(--ro)">RO</b> read-only</span>
-            <span><b style="color:var(--sig)">SIG</b> signatures only</span>
-            <span><b>OFF</b> excluded</span>
-          </span>
-        </div>
-        <div class="row">
-          <div class="files">
-            <div class="small muted">Pick each file's tier — the same selection drives the agent guard and the copy-paste prompt</div>
-            <input type="text" id="search" placeholder="Filter files..." style="width:100%; box-sizing:border-box; margin-top:6px;" />
-            <div class="bulk">
-              <span class="muted">Set all filtered:</span>
-              <button data-bulk="4">RW</button>
-              <button data-bulk="3">RO</button>
-              <button data-bulk="2">SIG</button>
-              <button data-bulk="0">OFF</button>
-            </div>
-            <div id="list" class="files-list"></div>
-          </div>
-          <div class="prompt">
-            <div class="small muted">
-              Format:
-              <select id="format">
-                <option value="markdown">markdown</option>
-                <option value="xml">xml</option>
-                <option value="plain">plain</option>
-              </select>
-              &nbsp; <span class="totals" id="totals"></span>
-            </div>
-            <textarea id="task" placeholder="Optional task / instructions to prepend..."></textarea>
-            <textarea id="prompt" readonly></textarea>
-            <div class="actions">
-              <button class="action" id="copy">Copy prompt</button>
-              <button class="action" id="download">Download .txt</button>
-              <button class="action secondary" id="save">Save scope (.consurg.yaml)</button>
-            </div>
-            <div id="status" class="small muted"></div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <script>
-      let files = [];
-      let tiers = {};
-      let composeTimer = null;
+def _choose_local_folder(initial: Path) -> Path | None:
+    """Open the operating system's folder picker and return a selected directory."""
+    try:
+        import tkinter as tk
+        from tkinter import filedialog
+    except ImportError as exc:  # pragma: no cover - depends on Python distribution
+        raise RuntimeError(
+            "The native folder picker is unavailable in this Python installation"
+        ) from exc
 
-      const TIER_LABELS = { 4: 'RW', 3: 'RO', 2: 'SIG', 0: 'OFF' };
+    root = None
+    try:
+        root = tk.Tk()
+        root.withdraw()
+        try:
+            root.attributes("-topmost", True)
+        except tk.TclError:
+            pass
+        selected = filedialog.askdirectory(
+            parent=root,
+            initialdir=str(initial),
+            mustexist=True,
+            title="Choose a folder for ChatGPT context",
+        )
+    except tk.TclError as exc:  # pragma: no cover - depends on desktop session
+        raise RuntimeError(
+            "The native folder picker requires a graphical desktop session"
+        ) from exc
+    finally:
+        if root is not None:
+            root.destroy()
 
-      async function loadFiles() {
-        const response = await fetch('/api/files');
-        const payload = await response.json();
-        files = payload.files || [];
-        document.getElementById('scopeName').value = payload.scope_name || '';
-        files.forEach((item) => {
-          tiers[item.path] = item.tier === 1 ? 0 : item.tier;
-        });
-        render();
-        scheduleCompose();
-      }
+    if not selected:
+        return None
+    chosen = Path(selected).expanduser().resolve()
+    if not chosen.is_dir():
+        raise RuntimeError("The selected folder is not available")
+    return chosen
 
-      function filteredFiles() {
-        const q = document.getElementById('search').value.toLowerCase();
-        return files.filter((f) => f.path.toLowerCase().includes(q));
-      }
 
-      function render() {
-        const list = document.getElementById('list');
-        list.innerHTML = '';
-        filteredFiles().forEach((file) => {
-          const row = document.createElement('div');
-          row.className = 'file-row';
-
-          const btns = document.createElement('div');
-          btns.className = 'tier-btns';
-          [4, 3, 2, 0].forEach((tier) => {
-            const b = document.createElement('button');
-            b.textContent = TIER_LABELS[tier];
-            if (tiers[file.path] === tier) {
-              b.className = 'on-' + tier;
-            }
-            b.disabled = file.denied && tier !== 0;
-            b.addEventListener('click', () => {
-              tiers[file.path] = tier;
-              render();
-              scheduleCompose();
-            });
-            btns.appendChild(b);
-          });
-
-          const label = document.createElement('span');
-          label.className = 'path';
-          label.textContent = file.path;
-          label.title = file.path;
-
-          const tokens = document.createElement('span');
-          tokens.className = 'tokens';
-          tokens.textContent = '~' + file.tokens + ' tok';
-
-          row.appendChild(btns);
-          row.appendChild(label);
-          if (file.denied) {
-            const blocked = document.createElement('span');
-            blocked.className = 'blocked';
-            blocked.textContent = 'policy';
-            row.appendChild(blocked);
-          }
-          row.appendChild(tokens);
-          list.appendChild(row);
-        });
-        updateTotals();
-      }
-
-      function selectedTiers() {
-        const out = {};
-        Object.entries(tiers).forEach(([path, tier]) => {
-          if (tier >= 2) { out[path] = tier; }
-        });
-        return out;
-      }
-
-      function updateTotals(serverTokens) {
-        const sel = selectedTiers();
-        const count = Object.keys(sel).length;
-        let est = 0;
-        files.forEach((f) => {
-          const t = sel[f.path];
-          if (t === 4 || t === 3) { est += f.tokens; }
-          else if (t === 2) { est += Math.min(f.tokens, 150); }
-        });
-        const shown = serverTokens != null ? serverTokens : est;
-        document.getElementById('totals').textContent =
-          count + ' files, ~' + shown.toLocaleString() + ' tokens';
-      }
-
-      function scheduleCompose() {
-        clearTimeout(composeTimer);
-        composeTimer = setTimeout(refreshPrompt, 250);
-      }
-
-      async function refreshPrompt() {
-        const fmt = document.getElementById('format').value;
-        const task = document.getElementById('task').value;
-        const response = await fetch('/api/compose', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            tiers: selectedTiers(),
-            format: fmt,
-            task: task,
-            scope_name: document.getElementById('scopeName').value,
-          })
-        });
-        const payload = await response.json();
-        document.getElementById('prompt').value = payload.prompt || '';
-        updateTotals(payload.tokens);
-        if (payload.skipped && payload.skipped.length) {
-          setStatus('Omitted: ' + payload.skipped.map((s) => s.path + ' (' + s.reason + ')').join(', '));
-        } else {
-          setStatus('');
-        }
-      }
-
-      async function copyPrompt() {
-        const text = document.getElementById('prompt').value;
-        try {
-          await navigator.clipboard.writeText(text);
-          setStatus('Copied to clipboard');
-        } catch {
-          setStatus('Copy failed. Use Ctrl+C to copy manually.');
-        }
-      }
-
-      function downloadPrompt() {
-        const text = document.getElementById('prompt').value;
-        const blob = new Blob([text], { type: 'text/plain;charset=utf-8' });
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = 'consurg-context.txt';
-        a.click();
-        URL.revokeObjectURL(url);
-        setStatus('Downloaded');
-      }
-
-      async function saveScope() {
-        const response = await fetch('/api/save-scope', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            tiers: selectedTiers(),
-            scope_name: document.getElementById('scopeName').value,
-          })
-        });
-        const payload = await response.json();
-        setStatus('Scope saved to ' + (payload.saved || '.consurg.yaml') + ' — ready for consurg run');
-      }
-
-      function setStatus(message) {
-        document.getElementById('status').textContent = message;
-      }
-
-      document.getElementById('search').addEventListener('input', render);
-      document.getElementById('format').addEventListener('change', scheduleCompose);
-      document.getElementById('task').addEventListener('input', scheduleCompose);
-      document.getElementById('copy').addEventListener('click', copyPrompt);
-      document.getElementById('download').addEventListener('click', downloadPrompt);
-      document.getElementById('save').addEventListener('click', saveScope);
-      document.querySelectorAll('[data-bulk]').forEach((btn) => {
-        btn.addEventListener('click', () => {
-          const tier = parseInt(btn.getAttribute('data-bulk'), 10);
-          filteredFiles().forEach((f) => {
-            if (!f.denied || tier === 0) { tiers[f.path] = tier; }
-          });
-          render();
-          scheduleCompose();
-        });
-      });
-
-      loadFiles();
-    </script>
-  </body>
-</html>
-"""
+def _build_html(access_token: str = "") -> str:
+    page = Path(__file__).with_name("file_context_ui.html").read_text(encoding="utf-8")
+    return page.replace("__CONSURG_ACCESS_TOKEN__", access_token)

--- a/consurg/render.py
+++ b/consurg/render.py
@@ -13,14 +13,18 @@ Tier semantics when rendering:
 
 from __future__ import annotations
 
+import os
+import stat
 from dataclasses import dataclass, field
 from pathlib import Path
 
 from consurg.enforce import resolve_tier
 from consurg.scope import Scope, pattern_matches
-from consurg.trace.signatures import extract_signatures
+from consurg.trace.signatures import extract_signatures_from_source
 
 FORMATS = ("markdown", "plain", "xml")
+HARD_MAX_FILE_BYTES = 10 * 1024 * 1024
+HARD_MAX_TOTAL_BYTES = 50 * 1024 * 1024
 
 _TIER_ACCESS_LABEL = {
     4: "read-write",
@@ -100,14 +104,24 @@ def compose_from_tiers(
         fmt = "markdown"
     limits = limits or RenderLimits()
     result = ComposeResult()
+    max_file_bytes = _bounded_limit(
+        limits.max_file_bytes, default=RenderLimits.max_file_bytes, maximum=HARD_MAX_FILE_BYTES
+    )
+    max_total_bytes = _bounded_limit(
+        limits.max_total_bytes, default=RenderLimits.max_total_bytes, maximum=HARD_MAX_TOTAL_BYTES
+    )
 
     ordered = sorted(
-        (p.replace("\\", "/"), t) for p, t in tiers.items() if t >= 1
+        (path.replace("\\", "/"), tier) for path, tier in tiers.items() if tier >= 1
     )
-    visible = [(p, t) for p, t in ordered if not _denied(p, limits.never_include)]
-    for p, t in ordered:
-        if _denied(p, limits.never_include):
-            result.skipped.append((p, "excluded by never_include policy"))
+    visible: list[tuple[str, int]] = []
+    for path, tier in ordered:
+        if _denied(path, limits.never_include):
+            result.skipped.append((path, "excluded by never_include policy"))
+        elif not _path_within_root(cwd / path, cwd):
+            result.skipped.append((path, "outside project root"))
+        else:
+            visible.append((path, tier))
 
     blocks: list[str] = [_header(scope_name, reason, task, fmt)]
     if visible:
@@ -119,14 +133,14 @@ def compose_from_tiers(
             result.included.append((rel, tier))
             continue
 
-        body, reason_skipped = _file_body(cwd / rel, tier, limits)
+        body, reason_skipped = _file_body(cwd / rel, tier, limits, cwd, max_file_bytes)
         if reason_skipped:
             result.skipped.append((rel, reason_skipped))
             continue
 
         block = _content_block(rel, tier, body, fmt)
         size = len(block.encode("utf-8"))
-        if total_bytes + size > limits.max_total_bytes:
+        if total_bytes + size > max_total_bytes:
             result.skipped.append((rel, "total size limit reached"))
             continue
         blocks.append(block)
@@ -135,6 +149,9 @@ def compose_from_tiers(
 
     if result.skipped:
         blocks.append(_skipped_block(result.skipped, fmt))
+
+    if fmt == "xml":
+        blocks.append("</context>")
 
     result.text = "\n".join(b for b in blocks if b).rstrip() + "\n"
     result.token_estimate = estimate_tokens(result.text)
@@ -155,6 +172,14 @@ def _denied(path: str, patterns: list[str]) -> bool:
         for p in patterns
         if str(p).strip()
     )
+
+
+def _path_within_root(path: Path, root: Path) -> bool:
+    try:
+        path.resolve(strict=False).relative_to(root.resolve(strict=False))
+        return True
+    except (OSError, RuntimeError, ValueError):
+        return False
 
 
 def _header(scope_name: str, reason: str, task: str, fmt: str) -> str:
@@ -187,37 +212,136 @@ def _header(scope_name: str, reason: str, task: str, fmt: str) -> str:
 
 
 def _tree_block(visible: list[tuple[str, int]], fmt: str) -> str:
-    rows = [f"{p}  [{_TIER_TAG.get(t, '?')}]" for p, t in visible]
-    tree = "\n".join(rows)
     if fmt == "xml":
+        rows = [
+            f'<file path="{_xml_escape(path)}" tier="{_TIER_TAG.get(tier, "?")}" />'
+            for path, tier in visible
+        ]
+        tree = "\n".join(rows)
         return f"<file_tree>\n{tree}\n</file_tree>\n"
+    rows = [f"{path}  [{_TIER_TAG.get(tier, '?')}]" for path, tier in visible]
+    tree = "\n".join(rows)
     if fmt == "plain":
         return f"FILES ({len(rows)}):\n{tree}\n"
     return f"## Files\n```\n{tree}\n```\n"
 
 
-def _file_body(
-    full_path: Path, tier: int, limits: RenderLimits
-) -> tuple[str, str | None]:
-    """Return (body, skip_reason). Signature tier extracts instead of reading."""
-    if not full_path.exists():
-        return "", "file not found"
+def _bounded_limit(value: object, *, default: int, maximum: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    if parsed <= 0:
+        return default
+    return min(parsed, maximum)
 
+
+def safe_read_context_file(
+    full_path: Path, root: Path, max_file_bytes: int
+) -> tuple[str | None, str | None]:
+    """Read a project file without following unsafe path components.
+
+    The component snapshots make a rename/symlink swap detectable on platforms
+    where a descriptor-relative walk is unavailable (notably Windows).
+    """
+    try:
+        root_path = Path(os.path.abspath(root))
+        path = Path(os.path.abspath(full_path))
+        relative = path.relative_to(root_path)
+    except (OSError, RuntimeError, ValueError):
+        return None, "outside project root"
+    if ".." in relative.parts:
+        return None, "outside project root"
+    try:
+        before = _path_component_identities(root_path, relative)
+    except FileNotFoundError:
+        return None, "file not found"
+    except ValueError:
+        return None, "symlink or reparse point"
+    except (OSError, RuntimeError):
+        return None, "unreadable"
+
+    limit = _bounded_limit(
+        max_file_bytes, default=RenderLimits.max_file_bytes, maximum=HARD_MAX_FILE_BYTES
+    )
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0)
+    try:
+        fd = os.open(path, flags)
+    except FileNotFoundError:
+        return None, "file not found"
+    except OSError:
+        return None, "unreadable"
+
+    try:
+        with os.fdopen(fd, "rb", closefd=True) as source:
+            opened = os.fstat(source.fileno())
+            payload = source.read(limit + 1)
+    except OSError:
+        return None, "unreadable"
+    try:
+        after = _path_component_identities(root_path, relative)
+    except (OSError, RuntimeError, ValueError):
+        return None, "path changed during read"
+
+    if before != after or _file_identity(opened) != before[-1][1]:
+        return None, "path changed during read"
+    if len(payload) > limit:
+        return None, "exceeds max_file_bytes"
+    if b"\x00" in payload:
+        return None, "binary file"
+    try:
+        return payload.decode("utf-8"), None
+    except UnicodeDecodeError:
+        return None, "binary file"
+
+
+def _path_component_identities(
+    root: Path, relative: Path
+) -> list[tuple[Path, tuple[int, int]]]:
+    """Snapshot every component, rejecting links and Windows reparse points."""
+    current = root
+    snapshots: list[tuple[Path, tuple[int, int]]] = []
+    for component in (".", *relative.parts):
+        if component != ".":
+            current /= component
+        entry = os.lstat(current)
+        if stat.S_ISLNK(entry.st_mode) or _is_reparse_point(entry):
+            raise ValueError("symlink or reparse point")
+        snapshots.append((current, _file_identity(entry)))
+    return snapshots
+
+
+def _file_identity(entry: os.stat_result) -> tuple[int, int]:
+    return entry.st_dev, entry.st_ino
+
+
+def _is_reparse_point(entry: os.stat_result) -> bool:
+    attributes = getattr(entry, "st_file_attributes", 0)
+    reparse = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+    return bool(attributes & reparse)
+
+
+def _file_body(
+    full_path: Path,
+    tier: int,
+    limits: RenderLimits,
+    root: Path,
+    max_file_bytes: int | None = None,
+) -> tuple[str, str | None]:
+    """Return safely-read content or signatures extracted from that content."""
+    file_limit = max_file_bytes or _bounded_limit(
+        limits.max_file_bytes, default=RenderLimits.max_file_bytes, maximum=HARD_MAX_FILE_BYTES
+    )
+    source, skipped = safe_read_context_file(full_path, root, file_limit)
+    if skipped:
+        return "", skipped
+    assert source is not None
     if tier == 2:
-        sigs = extract_signatures(str(full_path))
+        sigs = extract_signatures_from_source(source, full_path.suffix)
         if sigs:
             return "\n".join(sigs), None
         return "[no extractable signatures]", None
-
-    try:
-        if full_path.stat().st_size > limits.max_file_bytes:
-            return "", "exceeds max_file_bytes"
-        with full_path.open("rb") as f:
-            if b"\x00" in f.read(8192):
-                return "", "binary file"
-        return full_path.read_text(encoding="utf-8", errors="replace"), None
-    except OSError:
-        return "", "unreadable"
+    return source, None
 
 
 def _content_block(rel: str, tier: int, body: str, fmt: str) -> str:
@@ -248,6 +372,21 @@ def _skipped_block(skipped: list[tuple[str, str]], fmt: str) -> str:
 
 
 def _xml_escape(text: str) -> str:
+    text = "".join(char for char in text if _is_xml_1_0_character(char))
     return (
-        text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+        text.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+        .replace("'", "&apos;")
+    )
+
+
+def _is_xml_1_0_character(char: str) -> bool:
+    codepoint = ord(char)
+    return (
+        codepoint in (0x9, 0xA, 0xD)
+        or 0x20 <= codepoint <= 0xD7FF
+        or 0xE000 <= codepoint <= 0xFFFD
+        or 0x10000 <= codepoint <= 0x10FFFF
     )

--- a/consurg/trace/signatures.py
+++ b/consurg/trace/signatures.py
@@ -28,20 +28,28 @@ _PY_EXTENSIONS = {".py", ".pyi"}
 _TS_EXTENSIONS = {".ts", ".tsx", ".js", ".jsx", ".mts", ".mjs"}
 
 
-def extract_signatures(file_path: str) -> list[str]:
+def extract_signatures(file_path: str, max_file_bytes: int = 20000) -> list[str]:
+    """Extract signatures from a bounded UTF-8 source file (legacy API)."""
     path = Path(file_path)
-    suffix = path.suffix.lower()
-
     try:
-        source = path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
+        limit = max(0, int(max_file_bytes))
+        with path.open("rb") as source_file:
+            payload = source_file.read(limit + 1)
+        if len(payload) > limit:
+            return []
+        source = payload.decode("utf-8")
+    except (OSError, UnicodeDecodeError, TypeError, ValueError):
         return []
+    return extract_signatures_from_source(source, path.suffix)
 
+
+def extract_signatures_from_source(source: str, suffix: str) -> list[str]:
+    """Extract signatures from already-read source without reopening its path."""
+    suffix = suffix.lower()
     if suffix in _PY_EXTENSIONS:
         return _extract_python(source)
-    elif suffix in _TS_EXTENSIONS:
+    if suffix in _TS_EXTENSIONS:
         return _extract_ts(source)
-
     return []
 
 
@@ -49,7 +57,6 @@ def _extract_python(source: str) -> list[str]:
     sigs: list[str] = []
 
     for m in _PY_CLASS.finditer(source):
-        indent = m.group(1)
         name = m.group(2)
         bases = m.group(3)
         if bases:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,6 @@ consurg = "consurg.cli:app"
 
 [tool.setuptools.packages.find]
 include = ["consurg*"]
+
+[tool.setuptools.package-data]
+consurg = ["*.html"]

--- a/tests/test_file_context_ui.py
+++ b/tests/test_file_context_ui.py
@@ -1,16 +1,45 @@
+import json
+import os
+import threading
+from http.client import HTTPConnection
+from http.server import ThreadingHTTPServer
+from types import SimpleNamespace
+from xml.etree import ElementTree
+
+import pytest
+
+import yaml
+import consurg.file_context_ui as file_context_ui
+
+
 from consurg.file_context_ui import (
     BINARY_FILE_PLACEHOLDER,
-    FileContextUIConfig,
     LARGE_FILE_PLACEHOLDER,
+    FileContextUIConfig,
+    _build_html,
+    _make_request_handler,
+    _sanitize_tiers,
     compose_prompt,
     is_denied,
-    start_ui_server,
+    list_candidate_files,
     load_file_context_ui_config,
+    start_ui_server,
+    ScopeExpansionConfirmationRequired,
+    save_scope_tiers,
 )
+from consurg.render import HARD_MAX_FILE_BYTES, HARD_MAX_TOTAL_BYTES
 
 
 def test_denylist_matching():
-    patterns = [".git", "node_modules", "__pycache__", "*.pyc", "dist", "docs/private/*.md", "**/secret/**"]
+    patterns = [
+        ".git",
+        "node_modules",
+        "__pycache__",
+        "*.pyc",
+        "dist",
+        "docs/private/*.md",
+        "**/secret/**",
+    ]
     assert is_denied(".git/config", patterns)
     assert is_denied("node_modules/pkg/index.js", patterns)
     assert is_denied("__pycache__/x.pyc", patterns)
@@ -30,7 +59,9 @@ def test_compose_prompt_path_safety(tmp_path):
     allowed_rel = "allowed.py"
 
     config = load_file_context_ui_config(cwd)
-    output = compose_prompt([allowed_rel, "../outside-root.txt"], cwd, config, format="markdown")
+    output = compose_prompt(
+        [allowed_rel, "../outside-root.txt"], cwd, config, format="markdown"
+    )
     assert "outside-root.txt" not in output
     assert "## FILE: allowed.py" in output
 
@@ -51,7 +82,9 @@ def test_compose_prompt_limits_and_binary_detection(tmp_path):
         hide_excluded=False,
     )
 
-    output = compose_prompt(["good.txt", "binary.bin", "large.txt"], cwd, config, format="markdown")
+    output = compose_prompt(
+        ["good.txt", "binary.bin", "large.txt"], cwd, config, format="markdown"
+    )
     assert "## FILE: good.txt" in output
     assert BINARY_FILE_PLACEHOLDER in output
     assert LARGE_FILE_PLACEHOLDER in output
@@ -76,6 +109,407 @@ def test_compose_prompt_can_include_readme(tmp_path):
 
     assert "## FILE: README.md" in output
     assert "# Consurg" in output
+
+
+def test_legacy_xml_compose_is_valid_xml_1_0(tmp_path):
+    (tmp_path / "control.txt").write_text("ok\x01 & <tag>", encoding="utf-8")
+    config = FileContextUIConfig([], max_file_bytes=1000, max_total_bytes=1000, hide_excluded=False)
+
+    output = compose_prompt(["control.txt"], tmp_path, config, format="xml")
+
+    root = ElementTree.fromstring(output)
+    assert root.tag == "context"
+    assert root.find("file").text == "ok & <tag>"
+
+
+def test_invalid_ui_config_falls_back_to_safe_defaults(tmp_path):
+    (tmp_path / ".consurg.yaml").write_text("file_context_ui: [", encoding="utf-8")
+
+    config = load_file_context_ui_config(tmp_path)
+
+    assert ".git" in config.never_include
+    assert config.max_file_bytes == 20000
+    assert config.max_total_bytes == 200000
+
+def test_ui_config_clamps_repository_controlled_size_limits(tmp_path):
+    (tmp_path / ".consurg.yaml").write_text(
+        "file_context_ui:\n  max_file_bytes: 999999999999\n  max_total_bytes: 999999999999\n",
+        encoding="utf-8",
+    )
+
+    config = load_file_context_ui_config(tmp_path)
+
+    assert config.max_file_bytes == HARD_MAX_FILE_BYTES
+    assert config.max_total_bytes == HARD_MAX_TOTAL_BYTES
+
+
+
+def test_candidate_listing_includes_untracked_files_but_not_internal_dirs(
+    tmp_path, monkeypatch
+):
+    (tmp_path / "tracked.py").write_text("tracked", encoding="utf-8")
+    (tmp_path / "new.py").write_text("new", encoding="utf-8")
+    (tmp_path / ".llm-router").mkdir()
+    (tmp_path / ".llm-router" / "trace.jsonl").write_text("private", encoding="utf-8")
+    (tmp_path / "nested-repo").mkdir()
+
+    monkeypatch.setattr(
+        "consurg.file_context_ui.subprocess.run",
+        lambda *args, **kwargs: SimpleNamespace(
+            returncode=0,
+            stdout=b"tracked.py\0new.py\0.llm-router/trace.jsonl\0nested-repo\0",
+        ),
+    )
+
+    assert list_candidate_files(tmp_path) == ["new.py", "tracked.py"]
+
+
+def test_candidate_listing_preserves_nul_delimited_legal_whitespace(tmp_path, monkeypatch):
+    names = [" leading.py", "trailing .py"]
+    if os.name != "nt":
+        names.append("line\nbreak.py")
+    for name in names:
+        (tmp_path / name).write_text("ok", encoding="utf-8")
+
+    monkeypatch.setattr(
+        "consurg.file_context_ui.subprocess.run",
+        lambda *args, **kwargs: SimpleNamespace(
+            returncode=0, stdout="\0".join(names).encode("utf-8") + b"\0"
+        ),
+    )
+
+    assert list_candidate_files(tmp_path) == sorted(names)
+
+
+def test_candidate_listing_fallback_prunes_dependency_directories(
+    tmp_path, monkeypatch
+):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "main.py").write_text("print('ok')", encoding="utf-8")
+    (tmp_path / "node_modules").mkdir()
+    (tmp_path / "node_modules" / "package.js").write_text("ignored", encoding="utf-8")
+
+    def git_unavailable(*args, **kwargs):
+        raise FileNotFoundError
+
+    monkeypatch.setattr("consurg.file_context_ui.subprocess.run", git_unavailable)
+
+    assert list_candidate_files(tmp_path) == ["src/main.py"]
+
+
+def test_sanitize_tiers_restricts_requests_to_visible_policy_allowed_files(tmp_path):
+    (tmp_path / "safe.py").write_text("safe", encoding="utf-8")
+    (tmp_path / "secret.env").write_text("secret", encoding="utf-8")
+    outside = tmp_path.parent / "outside.py"
+    outside.write_text("outside", encoding="utf-8")
+
+    result = _sanitize_tiers(
+        {
+            "safe.py": 3,
+            "secret.env": 4,
+            "../outside.py": 4,
+            "not-listed.py": 4,
+            "off.py": 0,
+        },
+        tmp_path,
+        allowed_paths={"safe.py", "secret.env"},
+        deny_patterns=["*.env"],
+    )
+
+    assert result == {"safe.py": 3}
+
+
+def test_scope_save_preserves_unchanged_wildcards_and_unmatched_entries(tmp_path):
+    (tmp_path / "src").mkdir()
+    for name in ("a.py", "b.py"):
+        (tmp_path / "src" / name).write_text(name, encoding="utf-8")
+    (tmp_path / ".consurg.yaml").write_text(
+        "version: 1\nworking_set: ['src/*.py', 'missing.py']\n",
+        encoding="utf-8",
+    )
+    candidates = ["src/a.py", "src/b.py"]
+    save_scope_tiers(
+        tmp_path,
+        {path: 4 for path in candidates},
+        candidates=candidates,
+        previous_tiers={path: 4 for path in candidates},
+    )
+
+    saved = yaml.safe_load((tmp_path / ".consurg.yaml").read_text(encoding="utf-8"))
+    assert saved["working_set"] == ["src/*.py", "missing.py"]
+
+
+def test_scope_save_requires_confirmation_before_expanding_wildcard(tmp_path):
+    (tmp_path / "src").mkdir()
+    for name in ("a.py", "b.py"):
+        (tmp_path / "src" / name).write_text(name, encoding="utf-8")
+    (tmp_path / ".consurg.yaml").write_text(
+        "version: 1\nworking_set: ['src/*.py', 'missing.py']\n",
+        encoding="utf-8",
+    )
+    candidates = ["src/a.py", "src/b.py"]
+    with pytest.raises(ScopeExpansionConfirmationRequired):
+        save_scope_tiers(
+            tmp_path,
+            {"src/b.py": 4},
+            candidates=candidates,
+            previous_tiers={path: 4 for path in candidates},
+        )
+
+    save_scope_tiers(
+        tmp_path,
+        {"src/b.py": 4},
+        candidates=candidates,
+        previous_tiers={path: 4 for path in candidates},
+        confirm_wildcard_expansion=True,
+    )
+    saved = yaml.safe_load((tmp_path / ".consurg.yaml").read_text(encoding="utf-8"))
+    assert saved["working_set"] == ["missing.py", "src/b.py"]
+
+
+def test_picker_api_rejects_missing_and_invalid_tokens(tmp_path):
+    (tmp_path / "safe.py").write_text("safe", encoding="utf-8")
+    config = load_file_context_ui_config(tmp_path)
+    handler = _make_request_handler(
+        tmp_path, config, ["safe.py"], {"safe.py": 1}, "scope", access_token="valid"
+    )
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        port = server.server_address[1]
+        for token in (None, "invalid"):
+            connection = HTTPConnection("127.0.0.1", port, timeout=5)
+            headers = {} if token is None else {"X-Consurg-Token": token}
+            connection.request("GET", "/api/files", headers=headers)
+            response = connection.getresponse()
+            response.read()
+            connection.close()
+            assert response.status == 403
+
+        connection = HTTPConnection("127.0.0.1", port, timeout=5)
+        connection.request(
+            "POST",
+            "/api/compose",
+            body="{}",
+            headers={"Content-Type": "application/json", "X-Consurg-Token": "invalid"},
+        )
+        response = connection.getresponse()
+        response.read()
+        connection.close()
+        assert response.status == 403
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def test_picker_api_requires_wildcard_expansion_confirmation(tmp_path):
+    (tmp_path / "src").mkdir()
+    for name in ("a.py", "b.py"):
+        (tmp_path / "src" / name).write_text(name, encoding="utf-8")
+    (tmp_path / ".consurg.yaml").write_text(
+        "version: 1\nworking_set: ['src/*.py']\n", encoding="utf-8"
+    )
+    config = load_file_context_ui_config(tmp_path)
+    handler = _make_request_handler(
+        tmp_path,
+        config,
+        ["src/a.py", "src/b.py"],
+        {"src/a.py": 4, "src/b.py": 4},
+        "scope",
+        access_token="valid",
+    )
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        connection = HTTPConnection("127.0.0.1", server.server_address[1], timeout=5)
+        connection.request(
+            "POST",
+            "/api/save-scope",
+            body=json.dumps({"tiers": {"src/b.py": 4}}),
+            headers={"Content-Type": "application/json", "X-Consurg-Token": "valid"},
+        )
+        response = connection.getresponse()
+        body = json.loads(response.read())
+        connection.close()
+        assert response.status == 409
+        assert body["requires_wildcard_confirmation"] is True
+        assert "src/*.py" in (tmp_path / ".consurg.yaml").read_text(encoding="utf-8")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def test_save_is_serialized_with_folder_switch(tmp_path, monkeypatch):
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    (first / "alpha.py").write_text("alpha", encoding="utf-8")
+    (second / "beta.py").write_text("beta", encoding="utf-8")
+    config = load_file_context_ui_config(first)
+    handler = _make_request_handler(
+        first, config, ["alpha.py"], {"alpha.py": 1}, "scope", access_token="valid"
+    )
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    save_started = threading.Event()
+    release_save = threading.Event()
+    original_save = file_context_ui.save_scope_tiers
+
+    def delayed_save(*args, **kwargs):
+        save_started.set()
+        assert release_save.wait(timeout=5)
+        return original_save(*args, **kwargs)
+
+    monkeypatch.setattr("consurg.file_context_ui.save_scope_tiers", delayed_save)
+    monkeypatch.setattr("consurg.file_context_ui._choose_local_folder", lambda cwd: second)
+    port = server.server_address[1]
+    headers = {"Content-Type": "application/json", "X-Consurg-Token": "valid"}
+    results = {}
+
+    def post(name, path, payload):
+        connection = HTTPConnection("127.0.0.1", port, timeout=5)
+        connection.request("POST", path, body=json.dumps(payload), headers=headers)
+        response = connection.getresponse()
+        results[name] = response.status, response.read()
+        connection.close()
+
+    try:
+        save_thread = threading.Thread(
+            target=post, args=("save", "/api/save-scope", {"tiers": {"alpha.py": 4}})
+        )
+        save_thread.start()
+        assert save_started.wait(timeout=5)
+        folder_thread = threading.Thread(
+            target=post, args=("folder", "/api/open-folder", {})
+        )
+        folder_thread.start()
+        assert folder_thread.is_alive()
+        release_save.set()
+        save_thread.join(timeout=5)
+        folder_thread.join(timeout=5)
+        assert results["save"][0] == 200
+        assert results["folder"][0] == 200
+
+        connection = HTTPConnection("127.0.0.1", port, timeout=5)
+        connection.request("GET", "/api/files", headers={"X-Consurg-Token": "valid"})
+        response = connection.getresponse()
+        payload = json.loads(response.read())
+        connection.close()
+        assert response.status == 200
+        assert payload["root_name"] == "second"
+        assert [item["path"] for item in payload["files"]] == ["beta.py"]
+    finally:
+        release_save.set()
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def test_picker_html_exposes_folder_tree_and_chatgpt_actions():
+    html = _build_html()
+
+    assert '<html lang="en">' in html
+    assert 'class="tree-list"' in html
+    assert 'role="tree"' not in html
+    assert "checkbox.type = 'checkbox'" in html
+    assert 'id="chooseFolder"' in html
+    assert "/api/open-folder" in html
+    assert "Copy + open ChatGPT" in html
+
+
+def test_picker_api_switches_folder_and_rejects_forged_denied_paths(
+    tmp_path, monkeypatch
+):
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    (first / "alpha.py").write_text("ALPHA_CONTENT", encoding="utf-8")
+    (second / "beta.py").write_text("BETA_CONTENT", encoding="utf-8")
+    (second / "secret.env").write_text("TOP_SECRET", encoding="utf-8")
+    (second / ".consurg.yaml").write_text(
+        "file_context_ui:\n  never_include: ['*.env']\n", encoding="utf-8"
+    )
+
+    config = load_file_context_ui_config(first)
+    handler = _make_request_handler(
+        first,
+        config,
+        ["alpha.py"],
+        {"alpha.py": 1},
+        "first-scope",
+    )
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    port = server.server_address[1]
+    origin = f"http://127.0.0.1:{port}"
+    token = handler.access_token
+    monkeypatch.setattr(
+        "consurg.file_context_ui._choose_local_folder", lambda cwd: second
+    )
+
+    def request(path, payload, request_origin=origin):
+        connection = HTTPConnection("127.0.0.1", port, timeout=5)
+        connection.request(
+            "POST",
+            path,
+            body=json.dumps(payload),
+            headers={
+                "Content-Type": "application/json",
+                "Origin": request_origin,
+                "X-Consurg-Token": token,
+            },
+        )
+        response = connection.getresponse()
+        body = response.read()
+        connection.close()
+        return response.status, json.loads(body) if response.status < 400 else body
+
+    try:
+        status, opened = request("/api/open-folder", {})
+        assert status == 200
+        assert opened["root_name"] == "second"
+        assert any(file["path"] == "beta.py" for file in opened["files"])
+        assert next(file for file in opened["files"] if file["path"] == "secret.env")[
+            "denied"
+        ]
+        assert next(file for file in opened["files"] if file["path"] == "secret.env")[
+            "tier"
+        ] == 0
+
+        status, composed = request(
+            "/api/compose",
+            {"tiers": {"beta.py": 3, "secret.env": 4}, "format": "markdown"},
+        )
+        assert status == 200
+        assert "BETA_CONTENT" in composed["prompt"]
+        assert "TOP_SECRET" not in composed["prompt"]
+
+        status, _ = request(
+            "/api/save-scope",
+            {"tiers": {"beta.py": 1, "secret.env": 4}, "scope_name": "safe"},
+        )
+        assert status == 200
+        saved = yaml.safe_load((second / ".consurg.yaml").read_text(encoding="utf-8"))
+        assert saved["visible"] == ["beta.py"]
+        assert saved["working_set"] == []
+        assert saved["reference"] == []
+        assert saved["signatures"] == []
+        assert "secret.env" not in json.dumps(saved)
+
+        status, _ = request("/api/compose", {"tiers": {}}, "http://evil.example")
+        assert status == 403
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
 
 
 def test_start_ui_server_launches_browser_and_exits(tmp_path, monkeypatch):

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,6 +1,11 @@
 from pathlib import Path
+from xml.etree import ElementTree
+
+import pytest
 
 import yaml
+
+import consurg.render as render
 
 from consurg.file_context_ui import initial_tiers, save_scope_tiers
 from consurg.render import (
@@ -8,6 +13,7 @@ from consurg.render import (
     compose_from_scope,
     compose_from_tiers,
     estimate_tokens,
+    safe_read_context_file,
 )
 from consurg.scope import Scope
 
@@ -74,12 +80,43 @@ def test_compose_from_tiers_respects_limits_and_denylist(tmp_path):
 
 def test_compose_from_tiers_xml_format(tmp_path):
     cwd = _project(tmp_path)
+    ampersand_file = cwd / "src" / "terms&conditions.py"
+    ampersand_file.write_text("VALUE = 'quoted'\n", encoding="utf-8")
     result = compose_from_tiers(
-        {"src/auth.py": 3, "src/types.py": 2}, cwd, fmt="xml", task="review this"
+        {"src/auth.py": 3, "src/types.py": 2, "src/terms&conditions.py": 1},
+        cwd,
+        fmt="xml",
+        task="review <this>",
+        scope_name='scope "quoted"',
     )
+    root = ElementTree.fromstring(result.text)
+    assert root.tag == "context"
+    assert root.attrib["name"] == 'scope "quoted"'
+    assert root.findtext("task") == "review <this>"
+    assert root.find('.//file[@path="src/terms&conditions.py"]') is not None
     assert '<file path="src/auth.py" access="read-only">' in result.text
     assert '<signatures path="src/types.py"' in result.text
-    assert "<task>review this</task>" in result.text
+
+
+def test_compose_rejects_paths_and_symlinks_outside_root(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    cwd = _project(project)
+    outside = tmp_path / "outside.py"
+    outside.write_text("DO_NOT_LEAK = True\n", encoding="utf-8")
+
+    traversal = compose_from_tiers({"../outside.py": 3}, cwd)
+    assert "DO_NOT_LEAK" not in traversal.text
+    assert ("../outside.py", "outside project root") in traversal.skipped
+
+    link = cwd / "src" / "outside-link.py"
+    try:
+        link.symlink_to(outside)
+    except OSError:
+        pytest.skip("symlinks are unavailable on this platform")
+    linked = compose_from_tiers({"src/outside-link.py": 3}, cwd)
+    assert "DO_NOT_LEAK" not in linked.text
+    assert ("src/outside-link.py", "outside project root") in linked.skipped
 
 
 def test_compose_from_scope_resolves_tiers(tmp_path):
@@ -149,3 +186,89 @@ def test_save_scope_tiers_preserves_other_keys(tmp_path):
     assert data["reason"] == "why not"
     assert data["visible"] == ["src/**"]
     assert data["file_context_ui"] == {"max_file_bytes": 12345}
+
+
+def test_signature_tier_respects_max_file_bytes(tmp_path):
+    cwd = _project(tmp_path)
+    source = cwd / "src" / "large.py"
+    source.write_text("def hidden():\n    pass\n" + "# x\n" * 100, encoding="utf-8")
+
+    result = compose_from_tiers(
+        {"src/large.py": 2}, cwd, limits=RenderLimits(max_file_bytes=20)
+    )
+
+    assert ("src/large.py", "exceeds max_file_bytes") in result.skipped
+    assert "def hidden" not in result.text
+
+
+def test_safe_reader_rejects_nul_beyond_initial_chunk(tmp_path):
+    cwd = _project(tmp_path)
+    target = cwd / "src" / "late-nul.txt"
+    target.write_bytes(b"x" * 9000 + b"\x00after")
+
+    content, reason = safe_read_context_file(target, cwd, 10000)
+
+    assert content is None
+    assert reason == "binary file"
+
+
+def test_xml_render_sanitizes_forbidden_control_characters(tmp_path):
+    cwd = _project(tmp_path)
+    (cwd / "src" / "control.py").write_text("value = '\\x01'\n", encoding="utf-8")
+
+    result = compose_from_tiers(
+        {"src/control.py": 3},
+        cwd,
+        fmt="xml",
+        scope_name="scope\x01name",
+        reason="reason\x0btext",
+        task="task\x02text",
+    )
+
+    root = ElementTree.fromstring(result.text)
+    assert root.attrib["name"] == "scopename"
+    assert root.findtext("reason") == "reasontext"
+    assert root.findtext("task") == "tasktext"
+    assert "\x01" not in result.text
+
+
+def test_safe_reader_rejects_symlink_component_inside_project(tmp_path):
+    cwd = _project(tmp_path)
+    target = cwd / "src" / "auth.py"
+    link = cwd / "src" / "inside-link.py"
+    try:
+        link.symlink_to(target)
+    except OSError:
+        pytest.skip("symlinks are unavailable on this platform")
+
+    content, reason = safe_read_context_file(link, cwd, 20000)
+
+    assert content is None
+    assert reason == "symlink or reparse point"
+
+
+def test_safe_reader_omits_file_when_path_changes_after_open(tmp_path, monkeypatch):
+    cwd = _project(tmp_path)
+    target = cwd / "src" / "swap.py"
+    replacement = cwd / "src" / "replacement.py"
+    target.write_text("SECRET = 'original'\n", encoding="utf-8")
+    replacement.write_text("SECRET = 'replacement'\n", encoding="utf-8")
+    original_snapshot = render._path_component_identities
+    calls = 0
+
+    def swap_before_second_snapshot(root, relative):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            try:
+                target.unlink()
+                replacement.replace(target)
+            except OSError:
+                pytest.skip("open-file replacement is unavailable on this platform")
+        return original_snapshot(root, relative)
+
+    monkeypatch.setattr(render, "_path_component_identities", swap_before_second_snapshot)
+    content, reason = safe_read_context_file(target, cwd, 20000)
+
+    assert content is None
+    assert reason == "path changed during read"


### PR DESCRIPTION
## Summary

The scope picker is now a trustworthy local workbench instead of a flat file toggle list. Users can switch folders, navigate a nested file list, preserve all five scope tiers, and copy paste-ready context into ChatGPT without the UI diverging from the saved enforcement scope.

The follow-up also closes the safety gaps found after #21: rendered files are read through bounded, symlink/reparse-aware checks; XML is valid and escaped; localhost APIs require a per-launch token and enforce same-origin/candidate policies; wildcard scopes cannot be silently frozen into explicit paths; and concurrent folder/save/compose operations cannot publish stale state.

The HTML UI ships as package data, with its design contract documented in `DESIGN.md`.

## Verification

- `python -m pytest tests -q` — 419 passed
- targeted Ruff checks — passed
- `python -m compileall -q consurg tests` — passed
- `git diff --check` — passed
- built wheel contains `consurg/file_context_ui.html`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.6--sol-000000)