### PR TITLE
Fix map discovery for untracked files

### DIFF
--- a/consurg/cli.py
+++ b/consurg/cli.py
@@ -24,9 +24,8 @@ from consurg.audit import audit_storage_stats, load_audit_config, persist_trace,
 from consurg.pk_agents import scaffold_pk_agents
 from consurg.scope import Scope, load_scope
 from consurg.trace import DependencyGraph, resolve_python_imports, resolve_ts_imports
-from consurg.enforce import resolve_tier, resolve_tier_with_pattern
+from consurg.enforce import resolve_tier_with_pattern
 from consurg.file_context_ui import (
-    IGNORED_DIR_NAMES,
     compose_prompt,
     list_candidate_files,
     load_file_context_ui_config,
@@ -60,26 +59,7 @@ def _write_yaml(data: dict):
 
 
 def _repo_files() -> list[Path]:
-    cwd = Path.cwd()
-    try:
-        result = subprocess.run(
-            ["git", "ls-files"],
-            capture_output=True,
-            text=True,
-            cwd=str(cwd),
-        )
-        if result.returncode == 0:
-            return sorted(
-                Path(f) for f in result.stdout.strip().splitlines() if f.strip()
-            )
-    except FileNotFoundError:
-        pass
-
-    return sorted(
-        p.relative_to(cwd)
-        for p in cwd.rglob("*")
-        if p.is_file() and not any(part in IGNORED_DIR_NAMES for part in p.parts)
-    )
+    return [Path(path) for path in list_candidate_files(Path.cwd())]
 
 
 def _tier_label(tier: int) -> str:
@@ -511,7 +491,6 @@ def map_cmd(
         return
 
     tree = Tree(f"[bold]{scope.scope_name}[/bold]")
-    cwd = Path.cwd()
 
     tier_styles = {
         4: ("[RW]", "green", "block"),
@@ -823,7 +802,7 @@ def sandbox_profile(
         console.print("[dim]Setup commands:[/dim]")
         for cmd in profile.setup_commands:
             console.print(f"  {cmd}")
-        console.print(f"\n[dim]Teardown commands:[/dim]")
+        console.print("\n[dim]Teardown commands:[/dim]")
         for cmd in profile.teardown_commands:
             console.print(f"  {cmd}")
         console.print(f"\n[dim]Distro: {profile.wsl_distro}, Workspace: {profile.workspace_dir}[/dim]")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
-import os
+import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -248,6 +249,39 @@ def test_map_depth_limit(in_tmp):
     result = runner.invoke(app, ["map", "--depth", "1"])
     assert "top.py" in result.output
     assert "deep.py" not in result.output
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git is required")
+def test_map_includes_untracked_and_hides_ignored_files(in_tmp):
+    subprocess.run(["git", "init", "-q"], cwd=in_tmp, check=True)
+    (in_tmp / ".gitignore").write_text("ignored.py\n", encoding="utf-8")
+    (in_tmp / "tracked.py").write_text("tracked", encoding="utf-8")
+    (in_tmp / "untracked.py").write_text("untracked", encoding="utf-8")
+    (in_tmp / "ignored.py").write_text("ignored", encoding="utf-8")
+    subprocess.run(
+        ["git", "add", ".gitignore", "tracked.py"], cwd=in_tmp, check=True
+    )
+    runner.invoke(app, ["init", "discovery-test"])
+
+    result = runner.invoke(app, ["map"])
+
+    assert result.exit_code == 0
+    assert "tracked.py" in result.output
+    assert "untracked.py" in result.output
+    assert "ignored.py" not in result.output
+
+
+def test_map_warns_for_large_file_sets(in_tmp, monkeypatch):
+    runner.invoke(app, ["init", "large-test"])
+    monkeypatch.setattr(
+        "consurg.cli._repo_files",
+        lambda: [Path(f"file-{index}.py") for index in range(5001)],
+    )
+
+    result = runner.invoke(app, ["map", "--scoped-only"])
+
+    assert result.exit_code == 0
+    assert "Warning: 5001 files found" in result.output
+
 
 
 # CS-010: drift detection


### PR DESCRIPTION
`consurg map` and `consurg ls` once again include untracked, non-ignored project files while excluding paths covered by `.gitignore`. File discovery now reuses the same NUL-safe, ignore-aware implementation as the scope picker instead of maintaining a tracked-only code path.

Focused tests cover tracked, untracked, and ignored Git files plus the large-repository warning.

Verification: `421 passed`; Ruff, compileall, and `git diff --check` passed.

This replaces the remaining useful portion of #13 without its stale conflicting history.